### PR TITLE
Adds pod publishing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
             name: "Paywall",
             dependencies: [
                 .product(name: "TPInAppReceipt", package: "TPInAppReceipt")
+            ],
+            // A way to re-defined "Bundle.module" if using pods instead of SPM
+            swiftSettings: [
+              .define("SPM")
             ]),
         .testTarget(
             name: "PaywallTests",

--- a/Paywall.podspec
+++ b/Paywall.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+
+	s.name         = "Paywall"
+	s.version      = "1.0.7"
+	s.summary      = "Superwall: In-App Paywalls Made Easy"
+	s.description  = "Paywall is a client for the Superwall paywall iteration anbd event tracking system. It is an open source framework that provides a wrapper around Webkit for presenting and creating paywalls. The Superwall backend for implementing new paywalls lets you iterate on the fly in Swift or Objective-C easy!"
+
+	s.homepage     = "https://github.com/superwall-me/paywall-ios"
+	s.license      = "MIT"
+	s.source       = { :git => "https://github.com/superwall-me/paywall-ios", :tag => "#{s.version}" }
+
+	s.author       = { "Jake Mor" => "jake@superwall.me" }
+
+	s.swift_versions = ['5.3']
+	s.ios.deployment_target = '12.0'
+	s.requires_arc = true
+
+  s.source_files  = "Sources/**/*.{swift}"
+  s.resources  = "Sources/Paywall/*.xcassets"
+  s.dependency 'TPInAppReceipt', '~> 3.0.0'
+
+end

--- a/Sources/Paywall/BundleHelper.swift
+++ b/Sources/Paywall/BundleHelper.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  Paywall
+//
+//  Created by Brian Anglin on 9/14/21.
+//
+import Foundation
+
+#if !SPM
+private class BundleFinder {}
+extension Foundation.Bundle {
+        /// Returns the resource bundle associated with the current Swift module.
+        static var module: Bundle = {
+                // This is your `target.path` (located in your `Package.swift`) by replacing all the `/` by the `_`.
+                let bundleName = "Paywall_Paywall"
+                let candidates = [
+                        // Bundle should be present here when the package is linked into an App.
+                        Bundle.main.resourceURL,
+                        // Bundle should be present here when the package is linked into a framework.
+                        Bundle(for: BundleFinder.self).resourceURL,
+                        // For command-line tools.
+                        Bundle.main.bundleURL,
+                ]
+                for candidate in candidates {
+                        let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+                        if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                                return bundle
+                        }
+                }
+                return Bundle(for: BundleFinder.self)
+        }()
+}
+
+#endif


### PR DESCRIPTION
- Bundle Helper: Re-defines `Bundle.module` when it is not defined by SPM. It also introduces a build setting macro to exclude this new module from SPM builds. 
- Paywall.podspec: Provides a way to distribute the SDK via Cocoapods, working with Objective-C++ 🎉 



Must import the protocols first 
```
@protocol SKPaymentTransactionObserver;
@protocol SKProductsRequestDelegate;
#import <Paywall-Swift.h>
```
