### PR TITLE
Enable fractional seconds for timestamps

### DIFF
--- a/Sources/Paywall/Misc/Extensions.swift
+++ b/Sources/Paywall/Misc/Extensions.swift
@@ -44,7 +44,9 @@ internal extension UIColor {
 internal extension Date {
 
     var isoString: String {
-        return ISO8601DateFormatter().string(from: self)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: self)
     }
 }
 


### PR DESCRIPTION
I think this should allow us get a bit more granular w/ observed request & response timings. I haven't tested this end to end but wrote a script to validate the settings which looks correct. 

```swift
import Foundation

let date = Date.init(timeIntervalSinceNow: 0)

let secondFormatter = ISO8601DateFormatter();
secondFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds];

let defaultFormatter = ISO8601DateFormatter();

print("Seconds: ")
print(secondFormatter.string(from:  date))
print("Default: ")
print(defaultFormatter.string(from: date))
```

```
Seconds: 
2021-10-04T18:24:03.763Z
Default: 
2021-10-04T18:24:03Z
```