### PR TITLE
Update for compatibility with iOS 10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "object": { 
+  "object": {
     "pins": [
       {
         "package": "ASN1Swift",

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Paywall",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v10)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Paywall.xcodeproj/project.pbxproj
+++ b/Paywall.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -246,8 +246,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 49E56C13DC94177BCFDBE533 /* Build configuration list for PBXProject "Paywall" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -338,7 +336,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Paywall.xcodeproj/Paywall_Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -362,7 +360,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Paywall.xcodeproj/Paywall_Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -426,6 +424,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -482,6 +481,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Paywall.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Paywall.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Paywall.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Sources/Paywall/Debug/SWConsoleViewController.swift
+++ b/Sources/Paywall/Debug/SWConsoleViewController.swift
@@ -79,7 +79,9 @@ internal class SWConsoleViewController: UIViewController {
 
 		navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Done", style: .plain, target: self, action: #selector(addTapped))
 		navigationItem.rightBarButtonItem?.tintColor = PrimaryColor
-		navigationItem.largeTitleDisplayMode = .never
+        if #available(iOS 11.0, *) {
+            navigationItem.largeTitleDisplayMode = .never
+        }
 		
         productPicker.reloadAllComponents()
         reloadTableView()

--- a/Sources/Paywall/Misc/Debug.swift
+++ b/Sources/Paywall/Misc/Debug.swift
@@ -79,7 +79,11 @@ internal struct Logger {
 		if shouldPrint(logLevel: logLevel, scope: scope) {
 			
 			let formatter = ISO8601DateFormatter()
-			formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if #available(iOS 11.0, *) {
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            } else {
+                formatter.formatOptions = [.withInternetDateTime]
+            }
 			let dateString = formatter.string(from: Date()).replacingOccurrences(of: "T", with: " ").replacingOccurrences(of: "Z", with: "")
 			
 			dump(dumping, name: "[Superwall]  [\(dateString)]  \(logLevel.description)  \(scope.rawValue)  \(message ?? "")", indent: 0, maxDepth: 100, maxItems: 100)

--- a/Sources/Paywall/Misc/Extensions.swift
+++ b/Sources/Paywall/Misc/Extensions.swift
@@ -45,7 +45,11 @@ internal extension Date {
 
     var isoString: String {
 		let formatter = ISO8601DateFormatter()
-		formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if #available(iOS 11.0, *) {
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        } else {
+            formatter.formatOptions = [.withInternetDateTime]
+        }
 		return formatter.string(from: self)
     }
 }
@@ -93,7 +97,7 @@ internal extension SKProduct {
     }
     
     var localizedSubscriptionPeriod: String {
-        guard let subscriptionPeriod = self.subscriptionPeriod else { return "" }
+        guard #available(iOS 11.2, *), let subscriptionPeriod = self.subscriptionPeriod else { return "" }
         
         let dateComponents: DateComponents
         
@@ -112,7 +116,7 @@ internal extension SKProduct {
     var period: String {
         get {
 
-            guard let period = subscriptionPeriod else { return "" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "" }
 
             if period.unit == .day {
                 if period.numberOfUnits == 7 {
@@ -142,7 +146,7 @@ internal extension SKProduct {
     var periodWeeks: String {
         get {
             
-            guard let period = subscriptionPeriod else { return "" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "" }
             let c = period.numberOfUnits
             
             if period.unit == .day {
@@ -168,7 +172,7 @@ internal extension SKProduct {
     var periodMonths: String {
         get {
             
-            guard let period = subscriptionPeriod else { return "" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "" }
             let c = period.numberOfUnits
             
             if period.unit == .day {
@@ -194,7 +198,7 @@ internal extension SKProduct {
     var periodYears: String {
         get {
             
-            guard let period = subscriptionPeriod else { return "" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "" }
             let c = period.numberOfUnits
             
             if period.unit == .day {
@@ -220,7 +224,7 @@ internal extension SKProduct {
     var periodDays: String {
         get {
             
-            guard let period = subscriptionPeriod else { return "" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "" }
             let c = period.numberOfUnits
             
             if period.unit == .day {
@@ -254,7 +258,7 @@ internal extension SKProduct {
             numberFormatter.numberStyle = .currency
             numberFormatter.locale = locale
             
-            guard let period = subscriptionPeriod else { return "n/a" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "n/a" }
             let c = period.numberOfUnits
             var periods = 1.0 as Decimal
             let inputPrice = price as Decimal
@@ -290,7 +294,7 @@ internal extension SKProduct {
             numberFormatter.numberStyle = .currency
             numberFormatter.locale = locale
             
-            guard let period = subscriptionPeriod else { return "n/a" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "n/a" }
             let c = period.numberOfUnits
             var periods = 1.0 as Decimal
             let inputPrice = price as Decimal
@@ -326,7 +330,7 @@ internal extension SKProduct {
             numberFormatter.numberStyle = .currency
             numberFormatter.locale = locale
             
-            guard let period = subscriptionPeriod else { return "n/a" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "n/a" }
             let c = period.numberOfUnits
             var periods = 1.0 as Decimal
             let inputPrice = price as Decimal
@@ -363,7 +367,7 @@ internal extension SKProduct {
             numberFormatter.numberStyle = .currency
             numberFormatter.locale = locale
             
-            guard let period = subscriptionPeriod else { return "n/a" }
+            guard #available(iOS 11.2, *), let period = subscriptionPeriod else { return "n/a" }
             let c = period.numberOfUnits
             var periods = 1.0 as Decimal
             let inputPrice = price as Decimal
@@ -391,7 +395,7 @@ internal extension SKProduct {
 
     var hasFreeTrial: Bool {
         get {
-            if let _ = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let _ = introductoryPrice?.subscriptionPeriod {
                 return true
             } else {
                 return false
@@ -401,7 +405,7 @@ internal extension SKProduct {
 
     var trialPeriodDays: String {
         get {
-            if let trialPeriod = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let trialPeriod = introductoryPrice?.subscriptionPeriod {
                 let c = trialPeriod.numberOfUnits
 
                 if trialPeriod.unit == .day {
@@ -428,7 +432,7 @@ internal extension SKProduct {
     
     var trialPeriodWeeks: String {
         get {
-            if let trialPeriod = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let trialPeriod = introductoryPrice?.subscriptionPeriod {
                 let c = trialPeriod.numberOfUnits
 
                 if trialPeriod.unit == .day {
@@ -455,7 +459,7 @@ internal extension SKProduct {
     
     var trialPeriodMonths: String {
         get {
-            if let trialPeriod = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let trialPeriod = introductoryPrice?.subscriptionPeriod {
                 let c = trialPeriod.numberOfUnits
 
                 if trialPeriod.unit == .day {
@@ -482,7 +486,7 @@ internal extension SKProduct {
     
     var trialPeriodYears: String {
         get {
-            if let trialPeriod = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let trialPeriod = introductoryPrice?.subscriptionPeriod {
                 let c = trialPeriod.numberOfUnits
 
                 if trialPeriod.unit == .day {
@@ -510,7 +514,7 @@ internal extension SKProduct {
     var trialPeriodText: String {
         get {
 
-            if let trialPeriod = introductoryPrice?.subscriptionPeriod {
+            if #available(iOS 11.2, *), let trialPeriod = introductoryPrice?.subscriptionPeriod {
 
                 let units = trialPeriod.numberOfUnits
 

--- a/Sources/Paywall/Paywall/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/SWPaywallViewController.swift
@@ -63,9 +63,13 @@ internal class SWPaywallViewController: UIViewController {
 		wv.scrollView.maximumZoomScale = 1.0
 		wv.scrollView.minimumZoomScale = 1.0
 		wv.isOpaque = false
-		wv.scrollView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 11.0, *) {
+            wv.scrollView.contentInsetAdjustmentBehavior = .never
+        }
 		wv.scrollView.bounces = true
-		wv.scrollView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 11.0, *) {
+            wv.scrollView.contentInsetAdjustmentBehavior = .never
+        }
 		wv.scrollView.contentInset = .init(top: 0, left: 0, bottom: 0, right: 0)
 		wv.scrollView.scrollIndicatorInsets = .zero
 		wv.scrollView.showsVerticalScrollIndicator = false


### PR DESCRIPTION
This PR drops the minimum iOS version deployment target from iOS 12.0 to iOS 10.0 by wrapping a few calls with availability checks.

The bulk of these calls are related to SKProduct's `subscriptionPeriod` property (added in iOS 11.2). Before these changes, if the library couldn't get a value for this property, it would return either an empty string, or some placeholder, like `"n/a"`. I piggybacked the availability checks on these `guard`-`else` early returns.

The few remaining calls are related to large titles and ISO8601DateFormatter's `fractionalSeconds`, both added in iOS 11. I don't _think_ we need to be concerned about a fallback for these in iOS 10?

What I'm _not_ sure about is what changes are necessary for either CocoaPods or SPM. I dropped the minimum deployment target for both, but otherwise didn't make any changes.