### PR TITLE
Avoid using iOS 14 localized button name.

### DIFF
--- a/Sources/Paywall/Misc/GameControllerManager.swift
+++ b/Sources/Paywall/Misc/GameControllerManager.swift
@@ -59,7 +59,7 @@ internal class GameControllerManager: NSObject {
 	
 	func gamepadValueChanged(gamepad: GCExtendedGamepad, element: GCControllerElement) {
 		guard Paywall.isGameControllerEnabled else { return }
-		let name = element.buttonName
+		let name = element.buttonName(gamepad: gamepad)
 		if #available(iOS 13.0, *) {
 			switch element {
 				case gamepad.leftTrigger:
@@ -133,7 +133,7 @@ extension SWPaywallViewController: GameControllerDelegate {
 
 extension GCControllerElement {
     // the identifier of this gamecontroller element that is accepted by the
-    var buttonName: String {
+    func buttonName(gamepad: GCExtendedGamepad) -> String {
         switch self {
         case gamepad.leftTrigger:
             return "L2 Button"

--- a/Sources/Paywall/Misc/GameControllerManager.swift
+++ b/Sources/Paywall/Misc/GameControllerManager.swift
@@ -59,7 +59,7 @@ internal class GameControllerManager: NSObject {
 	
 	func gamepadValueChanged(gamepad: GCExtendedGamepad, element: GCControllerElement) {
 		guard Paywall.isGameControllerEnabled else { return }
-		let name = element.unmappedLocalizedName ?? "unknown"
+		let name = element.buttonName
 		if #available(iOS 13.0, *) {
 			switch element {
 				case gamepad.leftTrigger:
@@ -129,5 +129,54 @@ extension SWPaywallViewController: GameControllerDelegate {
 		
 	}
 	
+}
+
+extension GCControllerElement {
+    // the identifier of this gamecontroller element that is accepted by the
+    var buttonName: String {
+        switch self {
+        case gamepad.leftTrigger:
+            return "L2 Button"
+        case gamepad.leftShoulder:
+            return "L1 Button"
+        case gamepad.rightTrigger:
+            return "R2 Button"
+        case gamepad.rightShoulder:
+            return "R1 Button"
+        case gamepad.leftThumbstick:
+            return "Left Thumbstick"
+        case gamepad.leftThumbstickButton:
+            return "Left Thumbstick Button"
+        case gamepad.rightThumbstick:
+            return "Right Thumbstick"
+        case gamepad.rightThumbstickButton:
+            return "Right Thumbstick Button"
+        case gamepad.dpad:
+            return "Direction Pad"
+        case gamepad.dpad.down:
+            return "Direction Pad"
+        case gamepad.dpad.right:
+            return "Direction Pad"
+        case gamepad.dpad.up:
+            return "Direction Pad"
+        case gamepad.dpad.left:
+            return "Direction Pad"
+        case gamepad.buttonA:
+            return "A Button"
+        case gamepad.buttonB:
+            return "B Button"
+        case gamepad.buttonX:
+            return "X Button"
+        case gamepad.buttonY:
+            return "Y Button"
+        case gamepad.buttonMenu:
+            return "Menu Button"
+        case gamepad.buttonOptions:
+            return "Options Button"
+        default:
+//            Logger.debug(logLevel: .debug, scope: .gameControllerManager, message: "Unrecognized Button", info: ["button": element], error: nil)
+            return "Unknown Button"
+        }
+    }
 }
 

--- a/Sources/Paywall/Misc/GameControllerManager.swift
+++ b/Sources/Paywall/Misc/GameControllerManager.swift
@@ -59,8 +59,8 @@ internal class GameControllerManager: NSObject {
 	
 	func gamepadValueChanged(gamepad: GCExtendedGamepad, element: GCControllerElement) {
 		guard Paywall.isGameControllerEnabled else { return }
-		let name = element.buttonName(gamepad: gamepad)
 		if #available(iOS 13.0, *) {
+            let name = element.buttonName(gamepad: gamepad)
 			switch element {
 				case gamepad.leftTrigger:
 					self.valueChanged(name, gamepad.leftTrigger.value)
@@ -133,6 +133,7 @@ extension SWPaywallViewController: GameControllerDelegate {
 
 extension GCControllerElement {
     // the identifier of this gamecontroller element that is accepted by the
+    @available(iOS 13, macOS 10.15, *)
     func buttonName(gamepad: GCExtendedGamepad) -> String {
         switch self {
         case gamepad.leftTrigger:

--- a/Sources/Paywall/Misc/GameControllerManager.swift
+++ b/Sources/Paywall/Misc/GameControllerManager.swift
@@ -132,7 +132,7 @@ extension SWPaywallViewController: GameControllerDelegate {
 }
 
 extension GCControllerElement {
-    // the identifier of this gamecontroller element that is accepted by the
+    // the identifier of this gamecontroller element that is accepted by the paywall javascript event listeners
     @available(iOS 13, macOS 10.15, *)
     func buttonName(gamepad: GCExtendedGamepad) -> String {
         switch self {


### PR DESCRIPTION
Fix https://github.com/superwall-me/paywall-ios/issues/11

Now:
- Users in other languages will have game controller buttons on their paywall working
- iOS 13 users will no longer crash if they move their game controller around on the paywall