### PR TITLE
Moves loading by identifier to a GET rather than POST

### DIFF
--- a/Sources/Paywall/Network/Network.swift
+++ b/Sources/Paywall/Network/Network.swift
@@ -217,10 +217,32 @@ extension Network {
     }
 
     func paywallByIdentifier(identifier: String, completion: @escaping (Result<PaywallResponse, Swift.Error>) -> Void) {
+        // WARNING: Do not modify anything about this request without considering our cache eviction code
+        // we must know all the exact urls we need to invalidate so chaning the order, inclusion, etc of any query
+        // parameters will cause issues
         var components = URLComponents(string: "paywall/\(identifier)")!
         let queryPk = URLQueryItem(name: "pk", value: Store.shared.apiKey ?? "")
-        let queryLocale = URLQueryItem(name: "locale", value: DeviceHelper.shared.locale)
-        components.queryItems = [queryPk, queryLocale]
+
+
+        // In the config endpoint we return all the locales, this code will check if:
+        // 1. The device locale (ex: en_US) exists in the locales list
+        // 2. The shortend device locale (ex: en) exists in the locale list
+        // If either exist (preferring the most specific) include the locale in the
+        // the url as a query param.
+        var queryLocale: URLQueryItem? = nil
+        if Store.shared.locales.contains(DeviceHelper.shared.locale) {
+            queryLocale = URLQueryItem(name: "locale", value: DeviceHelper.shared.locale)
+        } else {
+            let shortLocale = DeviceHelper.shared.locale.split("_")[0]
+            if (Store.shared.locales.contains(shortLocale)) {
+                queryLocale = URLQueryItem(name: "locale", value: shortLocale)
+            }
+        }
+        if queryLocale != nil {
+            components.queryItems = [queryPk, queryLocale]
+        } else {
+            components.queryItems = [queryPk]
+        }
 
         let requestURL = components.url(relativeTo: baseURL)!
         var request = URLRequest(url: requestURL)

--- a/Sources/Paywall/Store/Store.swift
+++ b/Sources/Paywall/Store/Store.swift
@@ -22,6 +22,7 @@ internal class Store {
     public var aliasId: String?
 	public var didTrackFirstSeen = false
 	public var userAttributes = [String: Any]()
+    public var locales: Set<String> = Set<String>()
     
     public var userId: String? {
         return appUserId ?? aliasId ?? nil
@@ -74,6 +75,11 @@ internal class Store {
     }
     
 	func add(config: ConfigResponse) {
+        locales =  Set(
+            config.localization.locales.map {
+                (locale) in  return locale.locale
+            }
+        )
 		var data = [String: Bool]()
         config.triggers.filter({ (trigger) in
             switch(trigger.triggerVersion) {

--- a/Sources/Paywall/Types/ConfigTypes.swift
+++ b/Sources/Paywall/Types/ConfigTypes.swift
@@ -19,11 +19,20 @@ internal struct PaywallConfig: Decodable {
 	var products: [ProductConfig]
 }
 
+
+internal struct LocaleConfig: Decodable {
+    var locale: String
+}
+
+internal struct LocalizationConfig: Decodable {
+    var locales: [LocaleConfig]
+}
 internal struct ConfigResponse: Decodable {
 	var triggers: [Trigger]
 	var paywalls: [PaywallConfig]
 	var logLevel: Int
 	var postback: PostbackRequest
+    var localization: LocalizationConfig
 	
 	func cache() {
 		


### PR DESCRIPTION
To enable better caching via our CDN, this moves loading of paywalls by identifiers to get a GET request which will be cached more aggressively. 