### PR TITLE
Hotfix/event tracking params

### DIFF
--- a/Sources/Paywall/Network/Paywall Response/PaywallResponseManager.swift
+++ b/Sources/Paywall/Network/Paywall Response/PaywallResponseManager.swift
@@ -23,7 +23,6 @@ final class PaywallResponseManager: NSObject {
     completion: @escaping PaywallResponseCompletionBlock
   ) {
     do {
-      
       // if event is nil, this returns a TriggerResponseIdentifiers object with the given identifier
       let triggerIdentifiers = try PaywallResponseLogic.handleTriggerResponse(
         withPaywallId: identifier,

--- a/Sources/Paywall/Paywall/Events/InternalEvents.swift
+++ b/Sources/Paywall/Paywall/Events/InternalEvents.swift
@@ -33,8 +33,8 @@ extension Paywall {
 
     for key in params.keys {
       if let value = clean(input: params[key]) {
-        let key = "$\(key)"
-        eventParams[key] = value
+        let keyWithDollar = "$\(key)"
+        eventParams[keyWithDollar] = value
         delegateParams[key] = value // no $ for delegate methods
       }
     }

--- a/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
+++ b/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
@@ -43,7 +43,6 @@ final class PaywallManager {
     cached: Bool,
     completion: ((Result<SWPaywallViewController, NSError>) -> Void)? = nil
   ) {
-
     PaywallResponseManager.shared.getResponse(
       identifier: identifier,
       event: event

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -190,7 +190,7 @@ public final class Paywall: NSObject {
     if delegate != nil {
       Self.delegate = delegate
     }
-    
+
     SKPaymentQueue.default().add(self)
 		addActiveStateObservers()
 		fetchConfiguration()


### PR DESCRIPTION
Bug fix. The $ sign was being added to the params sent back to the delegate when they shouldn't have been.