### PR TITLE
Fixes evaluator tests

### DIFF
--- a/Sources/Paywall/Network/Paywall Response/PaywallResponseLogic.swift
+++ b/Sources/Paywall/Network/Paywall Response/PaywallResponseLogic.swift
@@ -275,7 +275,7 @@ enum PaywallResponseLogic {
 
       if product.type == .primary {
         isFreeTrialAvailable = appleProduct.hasFreeTrial
-        
+
         if hasPurchased(product),
           appleProduct.hasFreeTrial {
           isFreeTrialAvailable = false

--- a/Tests/PaywallTests/Network/Paywall Response/Mocks/MockIntroductoryPeriod.swift
+++ b/Tests/PaywallTests/Network/Paywall Response/Mocks/MockIntroductoryPeriod.swift
@@ -11,9 +11,7 @@ final class MockIntroductoryPeriod: SKProductDiscount {
   var testSubscriptionPeriod: MockSubscriptionPeriod
 
   override var subscriptionPeriod: SKProductSubscriptionPeriod {
-    get {
-      return testSubscriptionPeriod
-    }
+    return testSubscriptionPeriod
   }
 
   override var priceLocale: Locale {

--- a/Tests/PaywallTests/Paywall/Trigger Manager/ExpressionEvaluatorTests.swift
+++ b/Tests/PaywallTests/Paywall/Trigger Manager/ExpressionEvaluatorTests.swift
@@ -24,14 +24,41 @@ final class ExpressionEvaluatorTests: XCTestCase {
     XCTAssertTrue(result)
   }
 
-  /*func testExpressionEvaluatorTrue() {
+  func testExpressionEvaluatorTrue() {
     Storage.shared.userAttributes = ["a": "b"]
     let result = ExpressionEvaluator.evaluateExpression(
-      expression: "a == \"b\"",
-      eventData: EventData(name: "ss", parameters: ["a":"b"], createdAt: "")
+      expression: "user.a == \"b\"",
+      eventData: EventData(name: "ss", parameters: [:], createdAt: "")
     )
     XCTAssertTrue(result)
-  }*/
+  }
+
+    func testExpressionEvaluatorParams() {
+        Storage.shared.userAttributes = [:]
+      let result = ExpressionEvaluator.evaluateExpression(
+        expression: "params.a == \"b\"",
+        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+      )
+      XCTAssertTrue(result)
+    }
+
+    func testExpressionEvaluatorDeviceTrue() {
+        Storage.shared.userAttributes = [:]
+      let result = ExpressionEvaluator.evaluateExpression(
+        expression: "device.platform == \"iOS\"",
+        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+      )
+      XCTAssertTrue(result)
+    }
+
+    func testExpressionEvaluatorDeviceFalse() {
+        Storage.shared.userAttributes = [:]
+      let result = ExpressionEvaluator.evaluateExpression(
+        expression: "device.platform == \"Android\"",
+        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+      )
+      XCTAssertFalse(result)
+    }
 
   func testExpressionEvaluatorFalse() {
     Storage.shared.userAttributes = [:]

--- a/Tests/PaywallTests/Paywall/Trigger Manager/ExpressionEvaluatorTests.swift
+++ b/Tests/PaywallTests/Paywall/Trigger Manager/ExpressionEvaluatorTests.swift
@@ -14,7 +14,6 @@ final class ExpressionEvaluatorTests: XCTestCase {
     Storage.shared.clear()
   }
 
-  // TODO: Why is this failing?
 
   func testExpressionMatchesAll() {
     let result = ExpressionEvaluator.evaluateExpression(
@@ -33,32 +32,32 @@ final class ExpressionEvaluatorTests: XCTestCase {
     XCTAssertTrue(result)
   }
 
-    func testExpressionEvaluatorParams() {
-        Storage.shared.userAttributes = [:]
-      let result = ExpressionEvaluator.evaluateExpression(
-        expression: "params.a == \"b\"",
-        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
-      )
-      XCTAssertTrue(result)
-    }
+  func testExpressionEvaluatorParams() {
+    Storage.shared.userAttributes = [:]
+    let result = ExpressionEvaluator.evaluateExpression(
+      expression: "params.a == \"b\"",
+      eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+    )
+    XCTAssertTrue(result)
+  }
 
-    func testExpressionEvaluatorDeviceTrue() {
-        Storage.shared.userAttributes = [:]
-      let result = ExpressionEvaluator.evaluateExpression(
-        expression: "device.platform == \"iOS\"",
-        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
-      )
-      XCTAssertTrue(result)
-    }
+  func testExpressionEvaluatorDeviceTrue() {
+    Storage.shared.userAttributes = [:]
+    let result = ExpressionEvaluator.evaluateExpression(
+      expression: "device.platform == \"iOS\"",
+      eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+    )
+    XCTAssertTrue(result)
+  }
 
-    func testExpressionEvaluatorDeviceFalse() {
-        Storage.shared.userAttributes = [:]
-      let result = ExpressionEvaluator.evaluateExpression(
-        expression: "device.platform == \"Android\"",
-        eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
-      )
-      XCTAssertFalse(result)
-    }
+  func testExpressionEvaluatorDeviceFalse() {
+    Storage.shared.userAttributes = [:]
+    let result = ExpressionEvaluator.evaluateExpression(
+      expression: "device.platform == \"Android\"",
+      eventData: EventData(name: "ss", parameters: ["a": "b"], createdAt: "")
+    )
+    XCTAssertFalse(result)
+  }
 
   func testExpressionEvaluatorFalse() {
     Storage.shared.userAttributes = [:]

--- a/Tests/PaywallTests/Paywall/Trigger Manager/TriggerLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Trigger Manager/TriggerLogicTests.swift
@@ -177,14 +177,14 @@ class TriggerLogicTests: XCTestCase {
     // MARK: When
 
     let outcome = TriggerLogic.outcome(
-        forEvent: eventData,
+      forEvent: eventData,
       v1Triggers: v1Triggers,
       v2Triggers: v2Triggers
     )
 
     // MARK: Then
     guard case .noRuleMatch = outcome.result else {
-      return XCTFail("Incorrect outcome. Expected presentV2")
+      return XCTFail("Incorrect outcome. Expected noRuleMatch")
     }
     let confirmableAssignments = outcome.confirmableAssignments
     XCTAssertNil(confirmableAssignments)
@@ -235,7 +235,7 @@ class TriggerLogicTests: XCTestCase {
 
     // MARK: Then
     guard case .unknownEvent = outcome.result else {
-      return XCTFail("Incorrect outcome. Expected presentV2")
+      return XCTFail("Incorrect outcome. Expected unknown event")
     }
 
     let confirmableAssignments = outcome.confirmableAssignments
@@ -265,7 +265,7 @@ class TriggerLogicTests: XCTestCase {
 
     // MARK: Then
     guard case .presentV1 = outcome.result else {
-      return XCTFail("Incorrect outcome. Expected presentV2")
+      return XCTFail("Incorrect outcome. Expected presentV1")
     }
 
     let confirmableAssignments = outcome.confirmableAssignments

--- a/Tests/PaywallTests/Paywall/Trigger Manager/TriggerLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Trigger Manager/TriggerLogicTests.swift
@@ -137,8 +137,6 @@ class TriggerLogicTests: XCTestCase {
     XCTAssertEqual(confirmableAssignments, expectedConfirmableAssignments)
   }
 
-  // TODO: Fix this one: Why is the rule still matching when expression and params are diff?
-  /*
   func testEventTriggerOutcome_noRuleMatch() throws {
     // MARK: Given
 
@@ -155,7 +153,7 @@ class TriggerLogicTests: XCTestCase {
     )
     let triggerRule = TriggerRule(
       experimentId: experimentId,
-      expression: "a == c",
+      expression: "params.a == c",
       isAssigned: false,
       variant: variant,
       variantId: variantId
@@ -168,7 +166,7 @@ class TriggerLogicTests: XCTestCase {
     // EventData
     let eventData = EventData(
       name: eventName,
-      parameters: ["a":"b"],
+      parameters: ["a": "b"],
       createdAt: "2022-03-09T11:45:38.016Z"
     )
 
@@ -179,19 +177,18 @@ class TriggerLogicTests: XCTestCase {
     // MARK: When
 
     let outcome = TriggerLogic.outcome(
-      forEventName: eventName,
-      eventData: eventData,
+        forEvent: eventData,
       v1Triggers: v1Triggers,
       v2Triggers: v2Triggers
     )
 
     // MARK: Then
-    guard case let .noRuleMatch = outcome.result else {
+    guard case .noRuleMatch = outcome.result else {
       return XCTFail("Incorrect outcome. Expected presentV2")
     }
     let confirmableAssignments = outcome.confirmableAssignments
     XCTAssertNil(confirmableAssignments)
-  }*/
+  }
 
   func testEventTriggerOutcome_unknownEvent() throws {
     // MARK: Given


### PR DESCRIPTION
This PR uncomments a few evaluator tests, fixes them and adds a few more. 

I ran `swiftlint --fix` but it seems like there are still warnings. Maybe I'm doing something wrong. 