### PR TITLE
Feature/explicit trigger pre config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Product prices were being sent back to the dashboard with weird values like 89.999998. We fixed that.
 - Modal presentation now uses `.pageSheet` instead of `.formSheet`. This results in a less compact paywall popover on iPad. Thanks to Daniel Yoo from the Daily Bible Inspirations app for spotting that!
 - For SwiftUI users, we've fixed an issue where the explicitly triggered paywalls and presented paywalls would sometimes randomly dismiss. We found that state changes within the presenting view caused a rerendering of the view which temporarily reset the state of the binding that controlled the presentation of the paywall. This was causing the Paywall to dismiss.
+- Fixes an issue where the wrong paywall was shown if a trigger was fired before the config was fetched from the server. Thanks to Zac from Blue Candy for help with finding that :)
 
 2.3.0
 -----

--- a/Sources/Paywall/Models/Triggers/PreConfigTrigger.swift
+++ b/Sources/Paywall/Models/Triggers/PreConfigTrigger.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 01/06/2022.
+//
+
+import UIKit
+
+struct PreConfigTrigger {
+  let presentationInfo: PresentationInfo
+  var viewController: UIViewController?
+  var ignoreSubscriptionStatus: Bool = false
+  var onSkip: ((NSError?) -> Void)?
+  var onPresent: ((PaywallInfo?) -> Void)?
+  var onDismiss: PaywallDismissalCompletionBlock?
+}

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/PublicPaywallPresentation.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/PublicPaywallPresentation.swift
@@ -152,6 +152,22 @@ public extension Paywall {
       presentationInfo = .explicitTrigger(result.data)
     }
 
+    guard Paywall.shared.didFetchConfig else {
+      let trigger = PreConfigTrigger(
+        presentationInfo: presentationInfo,
+        viewController: viewController,
+        ignoreSubscriptionStatus: ignoreSubscriptionStatus,
+        onSkip: onSkip,
+        onPresent: onPresent,
+        onDismiss: { result in
+          if let onDismiss = onDismiss {
+            onDismissConverter(result, completion: onDismiss)
+          }
+        }
+      )
+      return Storage.shared.cachePreConfigTrigger(trigger)
+    }
+
     internallyPresent(
       presentationInfo,
       on: viewController,

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -75,7 +75,6 @@ public final class Paywall: NSObject {
 
 	var presentingWindow: UIWindow?
 	var didTryToAutoRestore = false
-  var eventsTrackedBeforeConfigWasFetched: [EventData] = []
 	var paywallWasPresentedThisSession = false
   var didFetchConfig = !Storage.shared.configRequestId.isEmpty
 
@@ -222,14 +221,35 @@ public final class Paywall: NSObject {
 	private func fetchConfiguration() {
     let requestId = UUID().uuidString
     Network.shared.getConfig(withRequestId: requestId) { [weak self] result in
+      guard let self = self else {
+        return
+      }
       switch result {
       case .success(let config):
         Storage.shared.addConfig(config, withRequestId: requestId)
         TriggerSessionManager.shared.createSessions(from: config)
-        self?.didFetchConfig = true
+        self.didFetchConfig = true
         config.cache()
-        self?.eventsTrackedBeforeConfigWasFetched.forEach { self?.handleImplicitTrigger(forEvent: $0) }
-        self?.eventsTrackedBeforeConfigWasFetched.removeAll()
+
+        Storage.shared.triggersFiredPreConfig.forEach { trigger in
+          switch trigger.presentationInfo.triggerType {
+          case .implicit:
+            guard let eventData = trigger.presentationInfo.eventData else {
+              return
+            }
+            self.handleImplicitTrigger(forEvent: eventData)
+          case .explicit:
+            Self.internallyPresent(
+              trigger.presentationInfo,
+              on: trigger.viewController,
+              ignoreSubscriptionStatus: trigger.ignoreSubscriptionStatus,
+              onPresent: trigger.onPresent,
+              onDismiss: trigger.onDismiss,
+              onFail: trigger.onSkip
+            )
+          }
+        }
+        Storage.shared.clearPreConfigTriggers()
       case .failure(let error):
         Logger.debug(
           logLevel: .error,
@@ -238,7 +258,7 @@ public final class Paywall: NSObject {
           info: nil,
           error: error
         )
-        self?.didFetchConfig = true
+        self.didFetchConfig = true
       }
     }
 	}
@@ -252,9 +272,6 @@ public final class Paywall: NSObject {
 			guard let self = self else {
         return
       }
-      guard self.didFetchConfig else {
-        return self.eventsTrackedBeforeConfigWasFetched.append(event)
-      }
 
       let outcome = PaywallLogic.canTriggerPaywall(
         eventName: event.name,
@@ -264,9 +281,15 @@ public final class Paywall: NSObject {
 
       switch outcome {
       case .triggerPaywall:
+        let presentationInfo: PresentationInfo = .implicitTrigger(event)
+
+        guard self.didFetchConfig else {
+          let trigger = PreConfigTrigger(presentationInfo: presentationInfo)
+          return Storage.shared.cachePreConfigTrigger(trigger)
+        }
         // delay in case they are presenting a view controller alongside an event they are calling
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-          Paywall.internallyPresent(.implicitTrigger(event))
+          Paywall.internallyPresent(presentationInfo)
         }
       case .disallowedEventAsTrigger:
         Logger.debug(

--- a/Sources/Paywall/Storage/Storage.swift
+++ b/Sources/Paywall/Storage/Storage.swift
@@ -32,6 +32,7 @@ class Storage {
   }
   // swiftlint:disable:next array_constructor
   var triggers: [String: Trigger] = [:]
+  private(set) var triggersFiredPreConfig: [PreConfigTrigger] = []
   private let cache: Cache
 
   init(cache: Cache = Cache()) {
@@ -104,6 +105,14 @@ class Storage {
 
     _ = trackEvent(SuperwallEvent.AppInstall())
     cache.write(true, forType: DidTrackAppInstall.self)
+  }
+
+  func cachePreConfigTrigger(_ trigger: PreConfigTrigger) {
+    triggersFiredPreConfig.append(trigger)
+  }
+
+  func clearPreConfigTriggers() {
+    triggersFiredPreConfig.removeAll()
   }
 
   private func save() {


### PR DESCRIPTION
## Changes in this pull request
Fixes an issue where the wrong paywall would show if firing a trigger immediately before config was fetched.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
