### PR TITLE
Push and No Animation Presentation Styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 -----
 
 ### Enhancements
+- New push presentation style. By selecting Push on the superwall dashboard, your paywall will push and pop in as if it's being pushed/popped from a navigation controller. If you are using UIKit, you can provide a view controller to `Paywall.trigger` like this: `Paywall.trigger(event: "MyEvent", on: self)`. This will make the push transition more realistic, by moving its view in the transition. 
 - New dedicated function for handling deeplinks: `Paywall.handleDeepLink(url)`
 - Deprecates old `track` functions. The only one you should use is `Paywall.track(_:_:)`, to which you pass an event name and a dictionary of parameters.
 - Adds a new way of internally tracking analytics associated with a paywall and the app session. This will greatly improve the Superwall dashboard analytics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 -----
 
 ### Enhancements
-- New push presentation style. By selecting Push on the superwall dashboard, your paywall will push and pop in as if it's being pushed/popped from a navigation controller. If you are using UIKit, you can provide a view controller to `Paywall.trigger` like this: `Paywall.trigger(event: "MyEvent", on: self)`. This will make the push transition more realistic, by moving its view in the transition. 
+- New _push_ presentation style. By selecting Push on the superwall dashboard, your paywall will push and pop in as if it's being pushed/popped from a navigation controller. If you are using UIKit, you can provide a view controller to `Paywall.trigger` like this: `Paywall.trigger(event: "MyEvent", on: self)`. This will make the push transition more realistic, by moving its view in the transition. Note: This is not backwards compatible with previous versions of the SDK.
+- New _no animation_ presentation style. By selecting No Animation in the superwall dashboard, you can disable presentation/dismissal animation. This release deprecates `Paywall.shouldAnimatePaywallDismissal` and `Paywall.shouldAnimatePaywallPresentation`.
 - New dedicated function for handling deeplinks: `Paywall.handleDeepLink(url)`
-- Deprecates old `track` functions. The only one you should use is `Paywall.track(_:_:)`, to which you pass an event name and a dictionary of parameters.
+- Deprecates old `track` functions. The only one you should use is `Paywall.track(_:_:)`, to which you pass an event name and a dictionary of parameters. Note: This is not backwards compatible with previous versions of the SDK.
 - Adds a new way of internally tracking analytics associated with a paywall and the app session. This will greatly improve the Superwall dashboard analytics.
 - Adds support for javascript expressions defined in rules on the Superwall dashboard.
 - Updates the SDK documentation.

--- a/Sources/Paywall/Documentation.docc/Extensions/PaywallExtension.md
+++ b/Sources/Paywall/Documentation.docc/Extensions/PaywallExtension.md
@@ -70,7 +70,7 @@ The ``Paywall/Paywall`` class is used to access all the features of the SDK. Bef
 - ``restoreFailedCloseButtonString``
 - ``localizationOverride(localeIdentifier:)``
 - ``shouldPreloadTriggers``
-- ``shouldAnimatePaywallDismissal``
-- ``shouldAnimatePaywallPresentation``
 - ``networkEnvironment``
 - ``PaywallNetworkEnvironment``
+- ``shouldAnimatePaywallDismissal``
+- ``shouldAnimatePaywallPresentation``

--- a/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
@@ -11,4 +11,5 @@ enum PaywallPresentationStyle: String, Decodable {
   case sheet = "SHEET"
   case modal = "MODAL"
   case fullscreen = "FULLSCREEN"
+  case push = "PUSH"
 }

--- a/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
@@ -12,4 +12,11 @@ enum PaywallPresentationStyle: String, Decodable {
   case modal = "MODAL"
   case fullscreen = "FULLSCREEN"
   case push = "PUSH"
+  case noAnimation = "NO_ANIMATION"
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(RawValue.self)
+    self = PaywallPresentationStyle(rawValue: rawValue) ?? .fullscreen
+  }
 }

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
@@ -1,0 +1,49 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 06/06/2022.
+//
+
+import UIKit
+
+enum TransitionState {
+  case presenting
+  case dismissing
+}
+
+final class PushTransition: NSObject, UIViewControllerAnimatedTransitioning {
+  var state: TransitionState
+  var animator: UIViewImplicitlyAnimating?
+
+  init(state: TransitionState) {
+    self.state = state
+    super.init()
+  }
+
+  func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    switch state {
+    case .presenting:
+      return 0.35
+    case .dismissing:
+      return 0.2
+    }
+  }
+
+  func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    guard let animator = PushTransitionLogic.interruptibleAnimator(
+      forState: state,
+      duration: transitionDuration(using: transitionContext),
+      animator: animator,
+      using: transitionContext
+    ) else {
+      return
+    }
+    self.animator = animator
+    animator.startAnimation()
+  }
+
+  func animationEnded(_ transitionCompleted: Bool) {
+    animator = nil
+  }
+}

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransitionLogic.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransitionLogic.swift
@@ -1,0 +1,118 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 07/06/2022.
+//
+
+import UIKit
+
+enum PushTransitionLogic {
+  static func interruptibleAnimator(
+    forState state: TransitionState,
+    duration: TimeInterval,
+    animator: UIViewImplicitlyAnimating?,
+    using transitionContext: UIViewControllerContextTransitioning
+  ) -> UIViewImplicitlyAnimating? {
+    if let animator = animator {
+      return animator
+    }
+
+    guard
+      let fromVC = transitionContext.viewController(forKey: .from),
+      let fromView = fromVC.view,
+      let toView = transitionContext.viewController(forKey: .to)?.view
+    else {
+      return nil
+    }
+
+    switch state {
+    case .presenting:
+      return presentingAnimator(
+        fromVC: fromVC,
+        fromView: fromView,
+        toView: toView,
+        duration: duration,
+        using: transitionContext
+      )
+    case .dismissing:
+      return dismissingAnimator(
+        fromVC: fromVC,
+        fromView: fromView,
+        toView: toView,
+        duration: duration,
+        using: transitionContext
+      )
+    }
+  }
+
+  private static func presentingAnimator(
+    fromVC: UIViewController,
+    fromView: UIView,
+    toView: UIView,
+    duration: TimeInterval,
+    using transitionContext: UIViewControllerContextTransitioning
+  ) -> UIViewImplicitlyAnimating? {
+    let container = transitionContext.containerView
+
+    let fromViewInitialFrame = transitionContext.initialFrame(for: fromVC)
+
+    var fromViewFinalFrame = fromViewInitialFrame
+    fromViewFinalFrame.origin.x = -fromViewFinalFrame.width / 3
+
+    var toViewInitialFrame = fromViewInitialFrame
+    toViewInitialFrame.origin.x = toView.frame.size.width
+
+    toView.frame = toViewInitialFrame
+    container.addSubview(toView)
+
+    let animator = UIViewPropertyAnimator(
+      duration: duration,
+      controlPoint1: CGPoint(x: 0, y: 0.5),
+      controlPoint2: CGPoint(x: 0.38, y: 0.9)
+    ) {
+      toView.frame = fromViewInitialFrame
+      fromView.frame = fromViewFinalFrame
+    }
+
+    animator.addCompletion { _ in
+      transitionContext.completeTransition(true)
+    }
+
+    return animator
+  }
+
+  private static func dismissingAnimator(
+    fromVC: UIViewController,
+    fromView: UIView,
+    toView: UIView,
+    duration: TimeInterval,
+    using transitionContext: UIViewControllerContextTransitioning
+  ) -> UIViewImplicitlyAnimating? {
+    var fromViewInitialFrame = transitionContext.initialFrame(for: fromVC)
+    fromViewInitialFrame.origin.x = 0
+
+    var fromViewFinalFrame = fromViewInitialFrame
+    fromViewFinalFrame.origin.x = fromViewFinalFrame.width
+
+    var toViewInitialFrame = fromViewInitialFrame
+    toViewInitialFrame.origin.x = -toView.frame.size.width / 3
+
+    toView.frame = toViewInitialFrame
+
+    let animator = UIViewPropertyAnimator(
+      duration: duration,
+      controlPoint1: CGPoint(x: 0.28, y: 0.2),
+      controlPoint2: CGPoint(x: 0.77, y: 0.76)
+    ) {
+      toView.frame = fromViewInitialFrame
+      fromView.frame = fromViewFinalFrame
+    }
+
+    animator.addCompletion { _ in
+      transitionContext.completeTransition(true)
+    }
+
+    return animator
+  }
+}

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -4,6 +4,7 @@
 //
 //  Created by brian on 7/21/21.
 //
+// swiftlint:disable file_length
 
 import WebKit
 import UIKit
@@ -416,6 +417,7 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
       self.contentPlaceholderImageView.tintColor = loadingColor.withAlphaComponent(0.5)
     }
 
+
     switch presentationStyle {
     case .sheet:
       modalPresentationStyle = .pageSheet
@@ -423,6 +425,9 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
       modalPresentationStyle = .pageSheet
     case .fullscreen:
       modalPresentationStyle = .overFullScreen
+    case .push:
+      modalPresentationStyle = .custom
+      transitioningDelegate = self
     }
   }
 
@@ -699,5 +704,21 @@ extension SWPaywallViewController: Stubbable {
       delegate: nil
     )
   }
-  // swiftlint:disable:next file_length
+}
+
+// MARK: - UIViewControllerTransitioningDelegate
+extension SWPaywallViewController: UIViewControllerTransitioningDelegate {
+  func animationController(
+    forPresented presented: UIViewController,
+    presenting: UIViewController,
+    source: UIViewController
+  ) -> UIViewControllerAnimatedTransitioning? {
+    return PushTransition(state: .presenting)
+  }
+
+  func animationController(
+    forDismissed dismissed: UIViewController
+  ) -> UIViewControllerAnimatedTransitioning? {
+    return PushTransition(state: .dismissing)
+  }
 }

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -427,6 +427,8 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
     case .push:
       modalPresentationStyle = .custom
       transitioningDelegate = self
+    case .noAnimation:
+      break
     }
   }
 
@@ -573,9 +575,17 @@ extension SWPaywallViewController {
 		} else {
 			prepareForPresentation()
       set(presentationInfo, dismissalBlock: dismissalBlock)
+
+      let isAnimated: Bool
+      if presentationStyle == .noAnimation {
+        isAnimated = false
+      } else {
+        isAnimated = Paywall.shouldAnimatePaywallPresentation
+      }
+
       presenter.present(
         self,
-        animated: Paywall.shouldAnimatePaywallPresentation
+        animated: isAnimated
       ) { [weak self] in
         self?.isPresented = true
         self?.presentationDidFinish()
@@ -590,7 +600,15 @@ extension SWPaywallViewController {
     completion: (() -> Void)? = nil
   ) {
     prepareToDismiss()
-		dismiss(animated: Paywall.shouldAnimatePaywallDismissal) { [weak self] in
+
+    let isAnimated: Bool
+    if presentationStyle == .noAnimation {
+      isAnimated = false
+    } else {
+      isAnimated = Paywall.shouldAnimatePaywallDismissal
+    }
+
+		dismiss(animated: isAnimated) { [weak self] in
       self?.didDismiss(
         dismissalResult,
         shouldCallCompletion: shouldCallCompletion,

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -417,7 +417,6 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
       self.contentPlaceholderImageView.tintColor = loadingColor.withAlphaComponent(0.5)
     }
 
-
     switch presentationStyle {
     case .sheet:
       modalPresentationStyle = .pageSheet

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -39,11 +39,13 @@ public final class Paywall: NSObject {
 	/// Animates paywall presentation. Defaults to `true`.
   ///
   /// Set this to `false` to globally disable paywall presentation animations.
+  @available(*, deprecated, message: "Set the Presentation Style to No Animation on the Superwall dashboard instead.")
 	public static var shouldAnimatePaywallPresentation = true
 
   /// Animates paywall dismissal. Defaults to `true`.
   ///
   /// Set this to `false` to globally disable paywall dismissal animations.
+  @available(*, deprecated, message: "Set the Presentation Style to No Animation on the Superwall dashboard instead.")
 	public static var shouldAnimatePaywallDismissal = true
 
 	/// Pre-loads and caches triggers and their associated paywalls and products upon initialization of the SDK. Defaults to `true`.

--- a/Tests/PaywallTests/Paywall/Session Events/SessionEventsDelegateMock.swift
+++ b/Tests/PaywallTests/Paywall/Session Events/SessionEventsDelegateMock.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 27/05/2022.
 //
+// swiftlint:disable all
 
 import Foundation
 @testable import Paywall
@@ -15,7 +16,7 @@ final class SessionEventsDelegateMock: SessionEventsDelegate {
   init(queue: SessionEventsQueue) {
     self.queue = queue
   }
-  
+
   func enqueue(_ triggerSession: TriggerSession) {
     queue.enqueue(triggerSession)
   }


### PR DESCRIPTION
## Changes in this pull request

Creates a custom animator to replicate a push/pop transition when presenting and dismissing the paywall.
If the dev is using UIKit and provides a viewController when triggering a paywall, the view that they've provided will also move during the transition. This provides a more realistic push/pop effect! This can't happen with SwiftUI unfortunately.

@anglinb this needs a new `PUSH` state sent from the API before this can work. You can test it just by commenting out the other modal presentation methods though.

Also adds NO_ANIMATION presentation state. Future proofs the enum to default to `fullscreen` if new additions to presentation style don't match. Deprecates old animation methods of presentation/dismissal.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
