### PR TITLE
Feature/future proof enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Modal presentation now uses `.pageSheet` instead of `.formSheet`. This results in a less compact paywall popover on iPad. Thanks to Daniel Yoo from the Daily Bible Inspirations app for spotting that!
 - For SwiftUI users, we've fixed an issue where the explicitly triggered paywalls and presented paywalls would sometimes randomly dismiss. We found that state changes within the presenting view caused a rerendering of the view which temporarily reset the state of the binding that controlled the presentation of the paywall. This was causing the Paywall to dismiss.
 - Fixes an issue where the wrong paywall was shown if a trigger was fired before the config was fetched from the server. Thanks to Zac from Blue Candy for help with finding that :)
+- Future proofs enums internally to increase backwards compatibility.
 
 2.3.0
 -----

--- a/Sources/Paywall/Misc/Extensions/JSONEncoder+Superwall.swift
+++ b/Sources/Paywall/Misc/Extensions/JSONEncoder+Superwall.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension JSONEncoder {
   /// Converts to snake case and ISO formats dates
-  static let endpoint: JSONEncoder = {
+  static let toSnakeCase: JSONEncoder = {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     encoder.dateEncodingStrategy = .formatted(Date.isoFormatter)
@@ -19,7 +19,7 @@ extension JSONEncoder {
 
 extension JSONDecoder {
   /// Converts from snake case and ISO formatted dates
-  static let endpoint: JSONDecoder = {
+  static let fromSnakeCase: JSONDecoder = {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .formatted(Date.isoFormatter)
     decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/Sources/Paywall/Misc/Extensions/URLSession+Request.swift
+++ b/Sources/Paywall/Misc/Extensions/URLSession+Request.swift
@@ -113,7 +113,7 @@ extension URLSession {
           ]
         )
 
-        let response = try JSONDecoder.endpoint.decode(
+        let response = try JSONDecoder.fromSnakeCase.decode(
           Response.self,
           from: data
         )

--- a/Sources/Paywall/Models/Events/EventsResponse.swift
+++ b/Sources/Paywall/Models/Events/EventsResponse.swift
@@ -12,6 +12,12 @@ struct EventsResponse: Codable {
   enum Status: String, Codable {
     case ok
     case partialSuccess
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let rawValue = try container.decode(RawValue.self)
+      self = Status(rawValue: rawValue) ?? .partialSuccess
+    }
   }
   var status: Status
   var invalidIndexes: [Int]?

--- a/Sources/Paywall/Models/SW Product/SWProductNumber.swift
+++ b/Sources/Paywall/Models/SW Product/SWProductNumber.swift
@@ -55,10 +55,18 @@ struct SWProductNumber: Codable {
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
 
-    try container.encode(formatted, forKey: .formatted)
-    // Note: price is encoded price as `String` (using `NSDecimalNumber.description`)
+    try container.encodeIfPresent(formatted, forKey: .formatted)
+    // Note: value is price encoded as `String` (using `NSDecimalNumber.description`)
     // to preserve precision and avoid values like "1.89999999"
     try container.encode(self.value.description, forKey: .value)
     try container.encode(self.format, forKey: .format)
+  }
+
+  init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    format = try values.decode(Format.self, forKey: .format)
+    formatted = try values.decodeIfPresent(String.self, forKey: .formatted)
+    let stringValue = try values.decode(String.self, forKey: .value)
+    value = Decimal(string: stringValue) ?? 0
   }
 }

--- a/Sources/Paywall/Models/SW Product/SWProductNumberGroup.swift
+++ b/Sources/Paywall/Models/SW Product/SWProductNumberGroup.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SWProductNumberGroup: Codable {
+struct SWProductNumberGroup: Encodable {
   var raw: SWProductNumber?
   var pretty: SWProductNumber?
   var rounded: SWProductNumber?

--- a/Sources/Paywall/Models/SW Product/SWProductPeriod.swift
+++ b/Sources/Paywall/Models/SW Product/SWProductPeriod.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SWProductPeriod: Codable {
+struct SWProductPeriod: Encodable {
   var full: String?
   var short: String?
   var abbreviated: String?
@@ -25,7 +25,7 @@ struct SWProductPeriod: Codable {
   }
 }
 
-struct SWPeriodTemplateVariable: Codable {
+struct SWPeriodTemplateVariable: Encodable {
   var `default`: SWProductPeriod
   var daily: SWProductPeriod
   var weekly: SWProductPeriod

--- a/Sources/Paywall/Models/SW Template Variables/SWPriceTemplateVariable.swift
+++ b/Sources/Paywall/Models/SW Template Variables/SWPriceTemplateVariable.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SWPriceTemplateVariable: Codable {
+struct SWPriceTemplateVariable: Encodable {
   var `default`: SWProductNumberGroup?
   var daily: SWProductNumberGroup?
   var weekly: SWProductNumberGroup?

--- a/Sources/Paywall/Models/SW Template Variables/SWSubscriptionTemplateVariable.swift
+++ b/Sources/Paywall/Models/SW Template Variables/SWSubscriptionTemplateVariable.swift
@@ -8,8 +8,8 @@
 import Foundation
 import StoreKit
 
-struct SWSubscriptionTemplateVariable: Codable {
-  enum TemplateType: String, Codable {
+struct SWSubscriptionTemplateVariable: Encodable {
+  enum TemplateType: String, Encodable {
     case subscription
     case trial
     case discount

--- a/Sources/Paywall/Models/SW Template Variables/SWTemplateVariable.swift
+++ b/Sources/Paywall/Models/SW Template Variables/SWTemplateVariable.swift
@@ -8,7 +8,7 @@
 import Foundation
 import StoreKit
 
-struct SWTemplateVariable: Codable {
+struct SWTemplateVariable: Encodable {
   var raw: SWProduct?
   var subscription: SWSubscriptionTemplateVariable?
   var trial: SWSubscriptionTemplateVariable?

--- a/Sources/Paywall/Models/Triggers/TriggerInfo.swift
+++ b/Sources/Paywall/Models/Triggers/TriggerInfo.swift
@@ -17,6 +17,12 @@ public struct Experiment: Equatable, Hashable, Codable {
     public enum VariantType: String, Codable, Hashable {
       case treatment = "TREATMENT"
       case holdout = "HOLDOUT"
+
+      public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(RawValue.self)
+        self = VariantType(rawValue: rawValue) ?? .treatment
+      }
     }
 
     /// The id of the experiment variant.

--- a/Sources/Paywall/Network/Endpoint.swift
+++ b/Sources/Paywall/Network/Endpoint.swift
@@ -107,7 +107,7 @@ struct Endpoint<Response: Decodable> {
 // MARK: - EventsResponse
 extension Endpoint where Response == EventsResponse {
   static func events(eventsRequest: EventsRequest) -> Self {
-    let bodyData = try? JSONEncoder.endpoint.encode(eventsRequest)
+    let bodyData = try? JSONEncoder.toSnakeCase.encode(eventsRequest)
 
     return Endpoint(
       components: Components(
@@ -120,7 +120,7 @@ extension Endpoint where Response == EventsResponse {
   }
 
   static func sessionEvents(_ session: SessionEventsRequest) -> Self {
-    let bodyData = try? JSONEncoder.endpoint.encode(session)
+    let bodyData = try? JSONEncoder.toSnakeCase.encode(session)
 
     return Endpoint(
       components: Components(
@@ -145,10 +145,10 @@ extension Endpoint where Response == PaywallResponse {
       return paywall(byIdentifier: identifier)
     } else if let event = event {
       let bodyDict = ["event": event.jsonData]
-      bodyData = try? JSONEncoder.endpoint.encode(bodyDict)
+      bodyData = try? JSONEncoder.toSnakeCase.encode(bodyDict)
     } else {
       let bodyDict = PaywallRequest(appUserId: Storage.shared.userId ?? "")
-      bodyData = try? JSONEncoder.endpoint.encode(bodyDict)
+      bodyData = try? JSONEncoder.toSnakeCase.encode(bodyDict)
     }
     return Endpoint(
       components: Components(
@@ -229,7 +229,7 @@ extension Endpoint where Response == Config {
 // MARK: - ConfirmedAssignmentResponse
 extension Endpoint where Response == ConfirmedAssignmentResponse {
   static func confirmAssignments(_ confirmableAssignments: ConfirmableAssignments) -> Self {
-    let bodyData = try? JSONEncoder.endpoint.encode(confirmableAssignments)
+    let bodyData = try? JSONEncoder.toSnakeCase.encode(confirmableAssignments)
 
     return Endpoint(
       components: Components(
@@ -245,7 +245,7 @@ extension Endpoint where Response == ConfirmedAssignmentResponse {
 // MARK: - PostbackResponse
 extension Endpoint where Response == PostBackResponse {
   static func postback(_ postback: Postback) -> Self {
-    let bodyData = try? JSONEncoder.endpoint.encode(postback)
+    let bodyData = try? JSONEncoder.toSnakeCase.encode(postback)
 
     return Endpoint(
       components: Components(

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallMessageHandler.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallMessageHandler.swift
@@ -52,7 +52,7 @@ final class PaywallMessageHandler: NSObject, WKScriptMessageHandler {
       return
     }
 
-    guard let wrappedPaywallEvents = try? JSONDecoder.endpoint.decode(
+    guard let wrappedPaywallEvents = try? JSONDecoder.fromSnakeCase.decode(
       WrappedPaywallEvents.self,
       from: bodyData
     ) else {

--- a/Tests/PaywallTests/Models/Config/ConfigResponseTests.swift
+++ b/Tests/PaywallTests/Models/Config/ConfigResponseTests.swift
@@ -56,7 +56,7 @@ let response = #"""
 
 final class ConfigTypeTests: XCTestCase {
   func testParseConfig() throws {
-    let parsedResponse = try! JSONDecoder.endpoint.decode(
+    let parsedResponse = try! JSONDecoder.fromSnakeCase.decode(
       Config.self,
       from: response.data(using: .utf8)!
     )


### PR DESCRIPTION
## Changes in this pull request

This future proofs a few enums. Not all of them can/should be future proofed - ProductType being one of those. If it's not primary/secondary/tertiary then I think it should fail otherwise it'll mess with existing types.

This also fixes an issue with decoding of a product value - it was being stored as a string but it wasn't being decoded into a Decimal.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
