### PR TITLE
Feature/paywall presentedviewcontroller

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,5 @@ Issue fixed: #
 - [ ] All tests pass. Demo project builds and runs.
 - [ ] I added tests, an experiment, or detailed why my change isn't tested.
 - [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
+- [ ] I have updated the SDK documentation as well as the online docs.
 - [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Adds support for javascript expressions defined in rules on the Superwall dashboard.
 - Updates the SDK documentation.
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
+- Exposes `Paywall.presentedViewController`. This gives you access to the `UIViewController` of the paywall incase you need to present a view controller on top of it.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Documentation.docc/Extensions/PaywallExtension.md
+++ b/Sources/Paywall/Documentation.docc/Extensions/PaywallExtension.md
@@ -75,3 +75,4 @@ The ``Paywall/Paywall`` class is used to access all the features of the SDK. Bef
 - ``shouldPreloadTriggers``
 - ``shouldAnimatePaywallDismissal``
 - ``shouldAnimatePaywallPresentation``
+- ``presentedViewController``

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -246,11 +246,16 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
 
 	override func viewWillDisappear(_ animated: Bool) {
 		super.viewWillDisappear(animated)
-		if isPresented,
-      !isSafariVCPresented,
-      !calledDismiss {
-				Paywall.delegate?.willDismissPaywall?()
-		}
+    guard isPresented else {
+      return
+    }
+    if isSafariVCPresented {
+      return
+    }
+    if calledDismiss {
+      return
+    }
+    Paywall.delegate?.willDismissPaywall?()
 	}
 
 	override func viewDidDisappear(_ animated: Bool) {

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -81,6 +81,11 @@ public final class Paywall: NSObject {
   /// Set this to `false` to prevent the paywall from dismissing on purchase/restore.
   public static var automaticallyDismiss = true
 
+  /// The presented paywall view controller.
+  public static var presentedViewController: UIViewController? {
+    return PaywallManager.shared.presentedViewController
+  }
+
   // MARK: - Private Properties
   /// Used as the reload function if a paywall takes to long to load. set in paywall.present
 	static var presentAgain = {}


### PR DESCRIPTION
## Changes in this pull request

- Adds `Paywall.presentedViewController` to expose the `UIViewController` of the presented paywall.
- Adds in PR checklist for documentation (which will show when it's merged to master).

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
