### PR TITLE
Changes purchase to use product_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Adds support for javascript expressions defined in rules on the Superwall dashboard.
 - Updates the SDK documentation.
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
+- Adds support for having more than 3 products on your paywall.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
@@ -26,7 +26,7 @@ final class PushTransition: NSObject, UIViewControllerAnimatedTransitioning {
     case .presenting:
       return 0.54
     case .dismissing:
-        return 0.54 * 0.618
+      return 0.54 * 0.618
     }
   }
 

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
@@ -38,7 +38,7 @@ enum PaywallEvent: Decodable {
   case restore
   case openUrl(url: URL)
   case openDeepLink(url: URL)
-  case purchase(product: ProductType)
+  case purchase(productId: String)
   case custom(data: String)
 }
 
@@ -56,7 +56,7 @@ extension PaywallEvent {
   // Everyone write to eventName, other may use the remaining keys
   private enum CodingKeys: String, CodingKey {
     case eventName
-    case product
+    case productId = "product_identifier"
     case url
     case link
     case data
@@ -77,8 +77,8 @@ extension PaywallEvent {
         self = .onReady
         return
       case .purchase:
-        if let product = try? values.decode(ProductType.self, forKey: .product) {
-          self = .purchase(product: product)
+        if let productId = try? values.decode(String.self, forKey: .productId) {
+          self = .purchase(productId: productId)
           return
         }
       case .restore:

--- a/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
@@ -55,9 +55,9 @@ final class WebEventHandler: WebEventDelegate {
       openDeepLink(url)
     case .restore:
       restorePurchases()
-    case .purchase(product: let type):
+    case .purchase(productId: let id):
       purchaseProduct(
-        withType: type,
+        withId: id,
         from: paywallResponse
       )
     case .custom(data: let customEvent):
@@ -154,11 +154,9 @@ final class WebEventHandler: WebEventDelegate {
     )
     delegate?.webView.configuration.userContentController.addUserScript(selectionScript)
 
-    // swiftlint:disable:next line_length
     let preventSelection = "var css = '*{-webkit-touch-callout:none;-webkit-user-select:none}'; var head = document.head || document.getElementsByTagName('head')[0]; var style = document.createElement('style'); style.type = 'text/css'; style.appendChild(document.createTextNode(css)); head.appendChild(style);"
     delegate?.webView.evaluateJavaScript(preventSelection)
 
-    // swiftlint:disable:next line_length
     let preventZoom: String = "var meta = document.createElement('meta');" + "meta.name = 'viewport';" + "meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';" + "var head = document.getElementsByTagName('head')[0];" + "head.appendChild(meta);"
     delegate?.webView.evaluateJavaScript(preventZoom)
   }
@@ -190,15 +188,12 @@ final class WebEventHandler: WebEventDelegate {
   }
 
   private func purchaseProduct(
-    withType productType: ProductType,
+    withId id: String,
     from paywallResponse: PaywallResponse
   ) {
     detectHiddenPaywallEvent("purchase")
     hapticFeedback()
-    let product = paywallResponse.products.first { $0.type == productType }
-    if let product = product {
-      delegate?.eventDidOccur(.initiatePurchase(productId: product.id))
-    }
+    delegate?.eventDidOccur(.initiatePurchase(productId: id))
   }
 
   private func handleCustomEvent(_ customEvent: String) {
@@ -235,12 +230,11 @@ final class WebEventHandler: WebEventDelegate {
 
   private func hapticFeedback() {
     if Paywall.isGameControllerEnabled { return }
-    
+
     if #available(iOS 13.0, *) {
       UIImpactFeedbackGenerator().impactOccurred(intensity: 0.7)
     } else {
       UIImpactFeedbackGenerator().impactOccurred()
     }
-  
   }
 }

--- a/Sources/Paywall/Paywall/Session Events/Trigger Session Manager/Model/Transaction/Product/TransactionProduct.swift
+++ b/Sources/Paywall/Paywall/Session Events/Trigger Session Manager/Model/Transaction/Product/TransactionProduct.swift
@@ -10,7 +10,7 @@ import StoreKit
 
 extension TriggerSession.Transaction {
   struct Product: Codable, Equatable {
-    /// The index of the product, primary = 0, secondary = 1, tertiary = 2.
+    /// The index of the product, primary = 0, secondary = 1, tertiary = 2 etc.
     let index: Int
 
     /// Product identifier


### PR DESCRIPTION
## Changes in this pull request

Accesses the product identifier from the webview callback to support an unlimited amount of paywall products.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
