### PR TITLE
Added sinceLastPaywallView to device params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Adds support for javascript expressions defined in rules on the Superwall dashboard.
 - Updates the SDK documentation.
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
+- Adds `daysSinceInstall`, `minutesSinceInstall`, `daysSinceLastPaywallView` and `minutesSinceLastPaywallView` as `device` parameters. These can be references in your rules and paywalls with `{{ device.paramName }}`.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Network/Device.swift
+++ b/Sources/Paywall/Network/Device.swift
@@ -143,6 +143,24 @@ final class DeviceHelper {
     return numberOfMinutes.minute ?? 0
   }
 
+  var daysSinceLastPaywallView: Int? {
+    guard let fromDate = Storage.shared.getLastPaywallView() else {
+      return nil
+    }
+    let toDate = Date()
+    let numberOfDays = Calendar.current.dateComponents([.day], from: fromDate, to: toDate)
+    return numberOfDays.day
+  }
+
+  var minutesSinceLastPaywallView: Int? {
+    guard let fromDate = Storage.shared.getLastPaywallView() else {
+      return nil
+    }
+    let toDate = Date()
+    let numberOfMinutes = Calendar.current.dateComponents([.minute], from: fromDate, to: toDate)
+    return numberOfMinutes.minute
+  }
+
   var templateDevice: TemplateDevice {
     let aliases: [String]
     if let alias = Storage.shared.aliasId {
@@ -172,7 +190,9 @@ final class DeviceHelper {
       appInstallDate: DeviceHelper.shared.appInstalledAtString,
       isMac: DeviceHelper.shared.isMac,
       daysSinceInstall: DeviceHelper.shared.daysSinceInstall,
-      minutesSinceInstall: DeviceHelper.shared.minutesSinceInstall
+      minutesSinceInstall: DeviceHelper.shared.minutesSinceInstall,
+      daysSinceLastPaywallView: DeviceHelper.shared.daysSinceLastPaywallView,
+      minutesSinceLastPaywallView: DeviceHelper.shared.minutesSinceLastPaywallView
     )
   }
 }

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -469,7 +469,7 @@ final class SWPaywallViewController: UIViewController, SWWebViewDelegate {
 
 	func trackOpen() {
     SessionEventsManager.shared.triggerSession.trackPaywallOpen()
-
+    Storage.shared.saveLastPaywallView()
     let trackedEvent = SuperwallEvent.PaywallOpen(paywallInfo: paywallInfo)
     Paywall.track(trackedEvent)
 	}

--- a/Sources/Paywall/Storage/CacheKeys.swift
+++ b/Sources/Paywall/Storage/CacheKeys.swift
@@ -82,3 +82,11 @@ enum Version: Storable {
   static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = DataStoreVersion
 }
+
+enum LastPaywallView: Storable {
+  static var key: String {
+    "store.lastPaywallView"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = Date
+}

--- a/Sources/Paywall/Storage/Storage.swift
+++ b/Sources/Paywall/Storage/Storage.swift
@@ -174,4 +174,15 @@ class Storage {
       forType: Transactions.self
     )
   }
+
+  func saveLastPaywallView() {
+    cache.write(
+      Date(),
+      forType: LastPaywallView.self
+    )
+  }
+
+  func getLastPaywallView() -> LastPaywallView.Value? {
+    return cache.read(LastPaywallView.self)
+  }
 }


### PR DESCRIPTION
## Changes in this pull request

Adds `daysSinceLastPaywallView` and `minutesSinceLastPaywallView` to device params.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
