### PR TITLE
Added openUrlInSafari and fixed deeplink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Fixes an issue where the keyboard couldn't be dismissed in the UIKit sample app.
 - Mentions SwiftLint as a requirement to run the sample apps.
 - Deprecates `Paywall.debugMode`. All logs are now controlled by setting `Paywall.logLevel`. The default `logLevel` is now `.warn`.
+- Fixes broken webview based deeplinks and closes the paywall view before calling the delegate handler.
 
 2.3.0
 -----

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
@@ -99,7 +99,6 @@ extension PaywallEvent {
           return
         }
       case .openDeepLink:
-        print("*** open it")
         if let urlString = try? values.decode(String.self, forKey: .link),
           let url = URL(string: urlString) {
           self = .openDeepLink(url: url)

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
@@ -49,7 +49,7 @@ extension PaywallEvent {
     case close
     case restore
     case openUrl = "open_url"
-    case openUrlInSafari = "open_url_in_safari"
+    case openUrlInSafari = "open_url_external"
     case openDeepLink = "open_deep_link"
     case purchase
     case custom

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallEvents.swift
@@ -36,7 +36,8 @@ enum PaywallEvent: Decodable {
 	case templateParamsAndUserAttributes
   case close
   case restore
-  case openUrl(url: URL)
+  case openUrl(_ url: URL)
+  case openUrlInSafari(_ url: URL)
   case openDeepLink(url: URL)
   case purchase(product: ProductType)
   case custom(data: String)
@@ -48,7 +49,8 @@ extension PaywallEvent {
     case close
     case restore
     case openUrl = "open_url"
-    case openDeepLink
+    case openUrlInSafari = "open_url_in_safari"
+    case openDeepLink = "open_deep_link"
     case purchase
     case custom
   }
@@ -87,10 +89,17 @@ extension PaywallEvent {
       case .openUrl:
         if let urlString = try? values.decode(String.self, forKey: .url),
           let url = URL(string: urlString) {
-          self = .openUrl(url: url)
+          self = .openUrl(url)
+          return
+        }
+      case .openUrlInSafari:
+        if let urlString = try? values.decode(String.self, forKey: .url),
+          let url = URL(string: urlString) {
+          self = .openUrlInSafari(url)
           return
         }
       case .openDeepLink:
+        print("*** open it")
         if let urlString = try? values.decode(String.self, forKey: .link),
           let url = URL(string: urlString) {
           self = .openDeepLink(url: url)

--- a/Sources/Paywall/Paywall/Paywall View Controller/PaywallPresentationResult.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/PaywallPresentationResult.swift
@@ -13,5 +13,6 @@ enum PaywallPresentationResult {
   case initiateRestore
   case custom(string: String)
   case openedURL(url: URL)
+  case openedUrlInSafari(_ url: URL)
   case openedDeepLink(url: URL)
 }

--- a/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/SWPaywallViewController.swift
@@ -566,6 +566,18 @@ extension SWPaywallViewController: WebEventHandlerDelegate {
     self.isSafariVCPresented = true
     present(safariVC, animated: true)
   }
+
+  func openDeepLink(_ url: URL) {
+    dismiss(
+      .withResult(
+        paywallInfo: paywallInfo,
+        state: .closed
+      ),
+      shouldCallCompletion: true
+    ) { [weak self] in
+      self?.eventDidOccur(.openedDeepLink(url: url))
+    }
+  }
 }
 
 // MARK: - presentation logic

--- a/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
@@ -18,6 +18,7 @@ protocol WebEventHandlerDelegate: AnyObject {
   var isPresentedViewController: Bool { get }
 
   func eventDidOccur(_ paywallPresentationResult: PaywallPresentationResult)
+  func openDeepLink(_ url: URL)
   func presentSafari(_ url: URL)
 }
 
@@ -51,6 +52,8 @@ final class WebEventHandler: WebEventDelegate {
       delegate?.eventDidOccur(.closed)
     case .openUrl(let url):
       openUrl(url)
+    case .openUrlInSafari(let url):
+      openUrlInSafari(url)
     case .openDeepLink(let url):
       openDeepLink(url)
     case .restore:
@@ -173,14 +176,23 @@ final class WebEventHandler: WebEventDelegate {
     delegate?.presentSafari(url)
   }
 
+  private func openUrlInSafari(_ url: URL) {
+    detectHiddenPaywallEvent(
+      "openUrlInSafari",
+      userInfo: ["url": url]
+    )
+    hapticFeedback()
+    delegate?.eventDidOccur(.openedUrlInSafari(url))
+    UIApplication.shared.open(url)
+  }
+
   private func openDeepLink(_ url: URL) {
     detectHiddenPaywallEvent(
       "openDeepLink",
       userInfo: ["url": url]
     )
     hapticFeedback()
-    delegate?.eventDidOccur(.openedDeepLink(url: url))
-    // TODO: Handle deep linking
+    delegate?.openDeepLink(url)
   }
 
   private func restorePurchases() {

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -343,6 +343,9 @@ extension Paywall: SWPaywallViewControllerDelegate {
         )
 			case .openedURL(let url):
 				Paywall.delegate?.willOpenURL?(url: url)
+      case .openedUrlInSafari(let url):
+        // TODO: Is this the right delegate call? Should we create a new one?
+        Paywall.delegate?.willOpenURL?(url: url)
 			case .openedDeepLink(let url):
 				Paywall.delegate?.willOpenDeepLink?(url: url)
 			case .custom(let string):


### PR DESCRIPTION
## Changes in this pull request

- This adds in a `open_url_in_safari` event handler. This Will open the given link in Safari rather than in-app.
- When a deepLink is opened from the webview, it now closes the the paywall before calling `eventDidOccur(.openedDeepLink(url: url))`.
- Fixes the fact that webview based deep links didn't actually decode before.

### TODO

- This calls the delegate function `Paywall.delegate?.willOpenURL?(url: url)`. This is the same delegate function for a normal openUrl event. Should we be using this?
- Need to add to the changelog about openUrlInSafari - waiting to know what the data tag will be called before adding that.

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
