### PR TITLE
Feature/paywall presentation override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
 - Exposes `Paywall.presentedViewController`. This gives you access to the `UIViewController` of the paywall incase you need to present a view controller on top of it.
 - Adds `daysSinceInstall`, `minutesSinceInstall`, `daysSinceLastPaywallView`, `minutesSinceLastPaywallView` and `totalPaywallViews` as `device` parameters. These can be references in your rules and paywalls with `{{ device.paramName }}`.
+- Adds a `presentationStyleOverride` parameter to `Paywall.trigger()` and `Paywall.present()`. By setting this, you can override the configured presentation style on a per-trigger basis.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallPresentationStyle.swift
@@ -7,16 +7,40 @@
 
 import Foundation
 
-enum PaywallPresentationStyle: String, Decodable {
-  case sheet = "SHEET"
-  case modal = "MODAL"
-  case fullscreen = "FULLSCREEN"
-  case fullscreenNoAnimation = "NO_ANIMATION"
-  case push = "PUSH"
+@objc public enum PaywallPresentationStyle: Int, Decodable {
+  case sheet
+  case modal
+  case fullscreen
+  case fullscreenNoAnimation
+  case push
+  case none
 
-  init(from decoder: Decoder) throws {
+  enum InternalPresentationStyle: String {
+    case sheet = "SHEET"
+    case modal = "MODAL"
+    case fullscreen = "FULLSCREEN"
+    case fullscreenNoAnimation = "NO_ANIMATION"
+    case push = "PUSH"
+  }
+
+  public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
-    let rawValue = try container.decode(RawValue.self)
-    self = PaywallPresentationStyle(rawValue: rawValue) ?? .fullscreen
+    let rawValue = try container.decode(InternalPresentationStyle.RawValue.self)
+    let internalPresentationStyle = InternalPresentationStyle(rawValue: rawValue) ?? .fullscreen
+
+    let presentationStyle: PaywallPresentationStyle
+    switch internalPresentationStyle {
+    case .sheet:
+      presentationStyle = .sheet
+    case .modal:
+      presentationStyle = .modal
+    case .fullscreen:
+      presentationStyle = .fullscreen
+    case .fullscreenNoAnimation:
+      presentationStyle = .fullscreenNoAnimation
+    case .push:
+      presentationStyle = .push
+    }
+    self = presentationStyle
   }
 }

--- a/Sources/Paywall/Models/Triggers/PreConfigTrigger.swift
+++ b/Sources/Paywall/Models/Triggers/PreConfigTrigger.swift
@@ -9,6 +9,7 @@ import UIKit
 
 struct PreConfigTrigger {
   let presentationInfo: PresentationInfo
+  var presentationStyleOverride: PaywallPresentationStyle?
   var viewController: UIViewController?
   var ignoreSubscriptionStatus = false
   var onFail: ((NSError) -> Void)?

--- a/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Extensions/View+PresentPaywall.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Extensions/View+PresentPaywall.swift
@@ -60,6 +60,7 @@ extension View {
   ///   - isPresented: A binding to a Boolean value that determines whether to present a paywall.
   ///
   ///     When the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing, the system sets `isPresented` to `false`.
+  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
   ///   - onPresent: A closure that's called after the paywall is presented. Accepts a `PaywallInfo?` object containing information about the paywall. Defaults to `nil`.
   ///   - onDismiss: The closure to execute after the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing.
   ///
@@ -71,6 +72,7 @@ extension View {
   ///     Accepts an `NSError?` with more details. Defaults to `nil`.
   public func presentPaywall(
     isPresented: Binding<Bool>,
+    presentationStyleOverride: PaywallPresentationStyle? = nil,
     onPresent: ((PaywallInfo?) -> Void)? = nil,
     onDismiss: ((PaywallDismissalResult) -> Void)? = nil,
     onFail: ((NSError) -> Void)? = nil

--- a/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Extensions/View+TriggerPaywall.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Extensions/View+TriggerPaywall.swift
@@ -74,6 +74,7 @@ extension View {
   ///   - shouldPresent: A binding to a Boolean value that determines whether to present a paywall.
   ///
   ///     The system sets `shouldPresent` to false if the trigger is not active or when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing.
+  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
   ///   - onPresent: A closure that's called after the paywall is presented. Accepts a `PaywallInfo?` object containing information about the paywall. Defaults to `nil`.
   ///   - onDismiss: The closure to execute after the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing.
   ///
@@ -86,6 +87,7 @@ extension View {
     forEvent event: String,
     withParams params: [String: Any]? = nil,
     shouldPresent: Binding<Bool>,
+    presentationStyleOverride: PaywallPresentationStyle? = nil,
     onPresent: ((PaywallInfo?) -> Void)? = nil,
     onDismiss: ((PaywallDismissalResult) -> Void)? = nil,
     onFail: ((NSError) -> Void)? = nil
@@ -95,6 +97,7 @@ extension View {
         shouldPresent: shouldPresent,
         event: event,
         params: params ?? [:],
+        presentationStyleOverride: presentationStyleOverride,
         onPresent: onPresent,
         onDismiss: onDismiss,
         onFail: onFail

--- a/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Modifiers/PaywallPresentationModifier.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Modifiers/PaywallPresentationModifier.swift
@@ -13,6 +13,7 @@ struct PaywallPresentationModifier: ViewModifier {
   @Binding var isPresented: Bool
   @State private var programmaticallySetIsPresented = false
   @State private var isInternallyPresenting = false
+  var presentationStyleOverride: PaywallPresentationStyle?
   var onPresent: ((PaywallInfo?) -> Void)?
   var onDismiss: ((PaywallDismissalResult) -> Void)?
   var onFail: ((NSError) -> Void)?
@@ -33,6 +34,7 @@ struct PaywallPresentationModifier: ViewModifier {
       isInternallyPresenting = true
       Paywall.internallyPresent(
         .defaultPaywall,
+        presentationStyleOverride: presentationStyleOverride ?? .none,
         onPresent: onPresent,
         onDismiss: { result in
           self.programmaticallySetIsPresented = true

--- a/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Modifiers/PaywallTriggerModifier.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/SwiftUI/Modifiers/PaywallTriggerModifier.swift
@@ -15,6 +15,7 @@ struct PaywallTriggerModifier: ViewModifier {
   @State private var isInternallyPresenting = false
   var event: String?
   var params: [String: Any]
+  var presentationStyleOverride: PaywallPresentationStyle?
   var onPresent: ((PaywallInfo?) -> Void)?
   var onDismiss: ((PaywallDismissalResult) -> Void)?
   var onFail: ((NSError) -> Void)?
@@ -47,6 +48,7 @@ struct PaywallTriggerModifier: ViewModifier {
 
       Paywall.internallyPresent(
         eventInfo,
+        presentationStyleOverride: presentationStyleOverride ?? .none,
         onPresent: onPresent,
         onDismiss: { result in
           self.programmaticallySetShouldPresent = true

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPaywallPresentation.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPaywallPresentation.swift
@@ -14,13 +14,16 @@ extension Paywall {
     on presentingViewController: UIViewController? = nil,
     cached: Bool = true,
     ignoreSubscriptionStatus: Bool = false,
+    presentationStyleOverride: PaywallPresentationStyle = .none,
     onPresent: ((PaywallInfo?) -> Void)? = nil,
     onDismiss: PaywallDismissalCompletionBlock? = nil,
     onFail: ((NSError) -> Void)? = nil
   ) {
+    let presentationStyleOverride = presentationStyleOverride == .none ? nil : presentationStyleOverride
     guard shared.configManager.didFetchConfig else {
       let trigger = PreConfigTrigger(
         presentationInfo: presentationInfo,
+        presentationStyleOverride: presentationStyleOverride,
         viewController: presentingViewController,
         ignoreSubscriptionStatus: ignoreSubscriptionStatus,
         onFail: onFail,
@@ -113,6 +116,7 @@ extension Paywall {
         paywallViewController.present(
           on: presenter,
           presentationInfo: presentationInfo,
+          presentationStyleOverride: presentationStyleOverride,
           dismissalBlock: onDismiss
         ) { success in
           if success {
@@ -124,6 +128,7 @@ extension Paywall {
                 presentationInfo,
                 on: presentingViewController,
                 cached: false,
+                presentationStyleOverride: presentationStyleOverride ?? .none,
                 onPresent: onPresent,
                 onDismiss: onDismiss,
                 onFail: onFail

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/PublicPaywallPresentation.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/PublicPaywallPresentation.swift
@@ -80,6 +80,7 @@ public extension Paywall {
   ///   - identifier: The identifier of the paywall you wish to present.
   ///   - on: The view controller to present the paywall on. Adds a new window to present on if `nil`. Defaults to `nil`.
   ///   - ignoreSubscriptionStatus: Presents the paywall regardless of subscription status if `true`. Defaults to `false`.
+  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
   ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a ``PaywallInfo``? object containing information about the paywall.
   ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal to the product id of the purchased product (if any) and a ``PaywallInfo``? object containing information about the paywall.
   ///   - onFail: A completion block that gets called when the paywall fails to present, either because an error occurred or because all paywalls are off. Defaults to `nil`.  Accepts an `NSError?` with more details.
@@ -87,6 +88,7 @@ public extension Paywall {
     identifier: String? = nil,
     on viewController: UIViewController? = nil,
     ignoreSubscriptionStatus: Bool = false,
+    presentationStyleOverride: PaywallPresentationStyle = .none,
     onPresent: ((PaywallInfo?) -> Void)? = nil,
     onDismiss: ((Bool, String?, PaywallInfo?) -> Void)? = nil,
     onFail: ((NSError?) -> Void)? = nil
@@ -101,6 +103,7 @@ public extension Paywall {
       presentationInfo,
       on: viewController,
       ignoreSubscriptionStatus: ignoreSubscriptionStatus,
+      presentationStyleOverride: presentationStyleOverride,
       onPresent: onPresent,
       onDismiss: { result in
         if let onDismiss = onDismiss {
@@ -128,6 +131,7 @@ public extension Paywall {
   ///   - params: Parameters you wish to pass along to the trigger (equivalent to params in ``Paywall/Paywall/track(_:_:)-2vkwo``). You can refer to these parameters in the rules you define in your campaign.
   ///   - on: The view controller to present the paywall on. Adds a new window to present on if `nil`. Defaults to `nil`.
   ///   - ignoreSubscriptionStatus: Presents the paywall regardless of subscription status if `true`. Defaults to `false`.
+  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
   ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a ``PaywallInfo``? object containing information about the paywall.
   ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal to the product id of the purchased product (if any) and a ``PaywallInfo``? object containing information about the paywall.
   ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts an `NSError?` with more details. It is recommended to check the error code to handle the onSkip callback. If the error code is `4000`, it means the user didn't match any rules. If the error code is `4001` it means the user is in a holdout group. Otherwise, a `404` error code means an error occurred.
@@ -136,6 +140,7 @@ public extension Paywall {
     params: [String: Any]? = nil,
     on viewController: UIViewController? = nil,
     ignoreSubscriptionStatus: Bool = false,
+    presentationStyleOverride: PaywallPresentationStyle = .none,
     onSkip: ((NSError?) -> Void)? = nil,
     onPresent: ((PaywallInfo?) -> Void)? = nil,
     onDismiss: ((Bool, String?, PaywallInfo?) -> Void)? = nil
@@ -156,6 +161,7 @@ public extension Paywall {
       presentationInfo,
       on: viewController,
       ignoreSubscriptionStatus: ignoreSubscriptionStatus,
+      presentationStyleOverride: presentationStyleOverride,
       onPresent: onPresent,
       onDismiss: { result in
         if let onDismiss = onDismiss {

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -41,7 +41,7 @@ public final class Paywall: NSObject {
 	/// Animates paywall presentation. Defaults to `true`.
   ///
   /// Set this to `false` to globally disable paywall presentation animations.
-  @available(*, deprecated, message: "Set the Presentation Style on the Superwall dashboard to No Animation instead of using this boolean.")
+  @available(*, deprecated, message: "Either set the Presentation Style on the Superwall dashboard to No Animation or, for a trigger-specific override, set presentationStyleOverride on Paywall.trigger().")
 	public static var shouldAnimatePaywallPresentation = true
 
   /// Animates paywall dismissal. Defaults to `true`.


### PR DESCRIPTION
## Changes in this pull request

Adds `presentationStyleOverride` to trigger and presentation. Due to having to support the devil's language (Objective-C), I had to make `presentationStyleOverride` non-optional, but with a default value of `.none`. So technically it is optional, but not really. Does that make sense? It turns out you can't have an optional enum in Objective-C! 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
