### PR TITLE
Added today to template device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Updates the SDK documentation.
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
 - Exposes `Paywall.presentedViewController`. This gives you access to the `UIViewController` of the paywall incase you need to present a view controller on top of it.
-- Adds `daysSinceInstall`, `minutesSinceInstall`, `daysSinceLastPaywallView`, `minutesSinceLastPaywallView` and `totalPaywallViews` as `device` parameters. These can be references in your rules and paywalls with `{{ device.paramName }}`.
+- Adds `today`, `daysSinceInstall`, `minutesSinceInstall`, `daysSinceLastPaywallView`, `minutesSinceLastPaywallView` and `totalPaywallViews` as `device` parameters. These can be references in your rules and paywalls with `{{ device.paramName }}`.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Models/Template/TemplateDevice.swift
+++ b/Sources/Paywall/Models/Template/TemplateDevice.swift
@@ -32,6 +32,7 @@ struct TemplateDevice: Codable {
   var daysSinceLastPaywallView: Int?
   var minutesSinceLastPaywallView: Int?
   var totalPaywallViews: Int
+  var today: String
 
   func toDictionary() -> [String: Any] {
     guard let data = try? JSONEncoder().encode(self) else {

--- a/Sources/Paywall/Network/Device.swift
+++ b/Sources/Paywall/Network/Device.swift
@@ -136,6 +136,12 @@ final class DeviceHelper {
     return numberOfDays.day ?? 0
   }
 
+  var todayString: String {
+    let date = Calendar.current.startOfDay(for: Date())
+    return date.isoString
+  }
+
+
   var minutesSinceInstall: Int {
     let fromDate = appInstallDate ?? Date()
     let toDate = Date()
@@ -197,7 +203,8 @@ final class DeviceHelper {
       minutesSinceInstall: DeviceHelper.shared.minutesSinceInstall,
       daysSinceLastPaywallView: DeviceHelper.shared.daysSinceLastPaywallView,
       minutesSinceLastPaywallView: DeviceHelper.shared.minutesSinceLastPaywallView,
-      totalPaywallViews: DeviceHelper.shared.totalPaywallViews
+      totalPaywallViews: DeviceHelper.shared.totalPaywallViews,
+      today: DeviceHelper.shared.todayString
     )
   }
 }


### PR DESCRIPTION
## Changes in this pull request

Adds `today` to the `TemplateDevice`, which is the start of today's date. All time is in GMT so when writing rules that involve dates it's important to remember the timezone!

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
