### PR TITLE
Feature/remote paywall presentation control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 - Adds `trialPeriodEndDate` as a product variable. This means you can tell your users when their trial period will end, e.g. `Start your trial today — you won't be billed until {{primary.trialPeriodEndDate}}` will print out `Start your trial today — you won't be billed until June 21, 2023`.
 - Exposes `Paywall.presentedViewController`. This gives you access to the `UIViewController` of the paywall incase you need to present a view controller on top of it.
 - Adds `daysSinceInstall`, `minutesSinceInstall`, `daysSinceLastPaywallView`, `minutesSinceLastPaywallView` and `totalPaywallViews` as `device` parameters. These can be references in your rules and paywalls with `{{ device.paramName }}`.
+- Paywalls can now be configured via the dashboard to always present, regardless of the subscription status of the user.
 
 ### Fixes
 - Adds the missing Superwall events `app_install`, `paywallWebviewLoad_fail` and `nonRecurringProduct_purchase`.

--- a/Sources/Paywall/Debug/SWDebugManager.swift
+++ b/Sources/Paywall/Debug/SWDebugManager.swift
@@ -42,7 +42,7 @@ final class SWDebugManager {
       withName: .paywallId
     )
 
-    SWDebugManager.shared.launchDebugger(withPaywallId: paywallId)
+    self.launchDebugger(withPaywallId: paywallId)
   }
 
 	/// Launches the debugger for you to preview paywalls.

--- a/Sources/Paywall/Models/Paywall/PaywallResponse.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallResponse.swift
@@ -27,6 +27,7 @@ struct PaywallResponse: Decodable {
   var paywalljsEvent: String
 
   var presentationStyleV2: PaywallPresentationStyle = .sheet
+  var presentationCondition: PresentationCondition
   var backgroundColorHex: String?
 
   /// The products associated with the paywall.
@@ -177,6 +178,7 @@ extension PaywallResponse: Stubbable {
     return PaywallResponse(
       url: "url",
       paywalljsEvent: "event",
+      presentationCondition: .checkPrimarySubscription,
       products: []
     )
   }

--- a/Sources/Paywall/Models/Paywall/PaywallResponse.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallResponse.swift
@@ -178,7 +178,7 @@ extension PaywallResponse: Stubbable {
     return PaywallResponse(
       url: "url",
       paywalljsEvent: "event",
-      presentationCondition: .checkPrimarySubscription,
+      presentationCondition: .checkUserSubscription,
       products: []
     )
   }

--- a/Sources/Paywall/Models/Paywall/PresentationCondition.swift
+++ b/Sources/Paywall/Models/Paywall/PresentationCondition.swift
@@ -9,11 +9,11 @@ import Foundation
 
 enum PresentationCondition: String, Decodable {
   case always = "ALWAYS"
-  case checkPrimarySubscription = "CHECK_PRIMARY_SUBSCRIPTION"
+  case checkUserSubscription = "CHECK_USER_SUBSCRIPTION"
 
   init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let rawValue = try container.decode(RawValue.self)
-    self = PresentationCondition(rawValue: rawValue) ?? .checkPrimarySubscription
+    self = PresentationCondition(rawValue: rawValue) ?? .checkUserSubscription
   }
 }

--- a/Sources/Paywall/Models/Paywall/PresentationCondition.swift
+++ b/Sources/Paywall/Models/Paywall/PresentationCondition.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 05/07/2022.
+//
+
+import Foundation
+
+enum PresentationCondition: String, Decodable {
+  case always = "ALWAYS"
+  case checkPrimarySubscription = "CHECK_PRIMARY_SUBSCRIPTION"
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(RawValue.self)
+    self = PresentationCondition(rawValue: rawValue) ?? .checkPrimarySubscription
+  }
+}

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPaywallPresentation.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPaywallPresentation.swift
@@ -80,7 +80,7 @@ extension Paywall {
         ) {
           return
         }
-        
+
         SessionEventsManager.shared.triggerSession.activateSession(
           for: presentationInfo,
           on: presentingViewController,

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPresentationLogic.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/InternalPresentationLogic.swift
@@ -1,0 +1,41 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 05/07/2022.
+//
+
+import Foundation
+
+enum InternalPresentationLogic {
+  static func shouldNotDisplayPaywall(
+    isUserSubscribed: Bool,
+    isDebuggerLaunched: Bool,
+    shouldIgnoreSubscriptionStatus: Bool,
+    presentationCondition: PresentationCondition? = nil
+  ) -> Bool {
+    if isDebuggerLaunched {
+      return false
+    }
+
+    func checkSubscriptionStatus() -> Bool {
+      guard isUserSubscribed else {
+        return false
+      }
+      if shouldIgnoreSubscriptionStatus {
+        return false
+      }
+      return true
+    }
+
+    guard let presentationCondition = presentationCondition else {
+      return checkSubscriptionStatus()
+    }
+
+    if presentationCondition == .always {
+      return false
+    }
+
+    return checkSubscriptionStatus()
+  }
+}

--- a/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
+++ b/Sources/Paywall/Paywall/Paywall Presentation/UIKit/Push Transition/PushTransition.swift
@@ -26,7 +26,7 @@ final class PushTransition: NSObject, UIViewControllerAnimatedTransitioning {
     case .presenting:
       return 0.54
     case .dismissing:
-        return 0.54 * 0.618
+      return 0.54 * 0.618
     }
   }
 

--- a/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
+++ b/Sources/Paywall/Paywall/Paywall View Controller/WebEventHandler.swift
@@ -235,12 +235,11 @@ final class WebEventHandler: WebEventDelegate {
 
   private func hapticFeedback() {
     if Paywall.isGameControllerEnabled { return }
-    
+
     if #available(iOS 13.0, *) {
       UIImpactFeedbackGenerator().impactOccurred(intensity: 0.7)
     } else {
       UIImpactFeedbackGenerator().impactOccurred()
     }
-  
   }
 }

--- a/Tests/PaywallTests/Paywall/Paywall Presentation/UIKit/InternalPresentationLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Paywall Presentation/UIKit/InternalPresentationLogicTests.swift
@@ -14,7 +14,7 @@ final class InternalPresentationLogicTests: XCTestCase {
       isUserSubscribed: true,
       isDebuggerLaunched: true,
       shouldIgnoreSubscriptionStatus: false,
-      presentationCondition: .checkPrimarySubscription
+      presentationCondition: .checkUserSubscription
     )
     XCTAssertFalse(outcome)
   }
@@ -64,7 +64,7 @@ final class InternalPresentationLogicTests: XCTestCase {
       isUserSubscribed: true,
       isDebuggerLaunched: false,
       shouldIgnoreSubscriptionStatus: false,
-      presentationCondition: .checkPrimarySubscription
+      presentationCondition: .checkUserSubscription
     )
     XCTAssertTrue(outcome)
   }

--- a/Tests/PaywallTests/Paywall/Paywall Presentation/UIKit/InternalPresentationLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Paywall Presentation/UIKit/InternalPresentationLogicTests.swift
@@ -1,0 +1,71 @@
+//
+//  InternalPresentationLogicTests.swift
+//  
+//
+//  Created by Yusuf Tör on 05/07/2022.
+//
+
+import XCTest
+@testable import Paywall
+
+final class InternalPresentationLogicTests: XCTestCase {
+  func test_shouldNotDisplayPaywall_debuggerLaunched() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: true,
+      isDebuggerLaunched: true,
+      shouldIgnoreSubscriptionStatus: false,
+      presentationCondition: .checkPrimarySubscription
+    )
+    XCTAssertFalse(outcome)
+  }
+
+  func test_shouldNotDisplayPaywall_noPresentationCondition_userIsNotSubscribed() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: false,
+      isDebuggerLaunched: false,
+      shouldIgnoreSubscriptionStatus: false,
+      presentationCondition: nil
+    )
+    XCTAssertFalse(outcome)
+  }
+
+  func test_shouldNotDisplayPaywall_noPresentationCondition_shouldIgnoreSubscriptionStatus() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: true,
+      isDebuggerLaunched: false,
+      shouldIgnoreSubscriptionStatus: true,
+      presentationCondition: nil
+    )
+    XCTAssertFalse(outcome)
+  }
+
+  func test_shouldNotDisplayPaywall_noPresentationCondition_shouldNotIgnoreSubscriptionStatus() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: true,
+      isDebuggerLaunched: false,
+      shouldIgnoreSubscriptionStatus: false,
+      presentationCondition: nil
+    )
+    XCTAssertTrue(outcome)
+  }
+
+  func test_shouldNotDisplayPaywall_presentationCondition_always() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: true,
+      isDebuggerLaunched: false,
+      shouldIgnoreSubscriptionStatus: false,
+      presentationCondition: .always
+    )
+    XCTAssertFalse(outcome)
+  }
+
+  func test_shouldNotDisplayPaywall_presentationCondition_checkSubscription() {
+    let outcome = InternalPresentationLogic.shouldNotDisplayPaywall(
+      isUserSubscribed: true,
+      isDebuggerLaunched: false,
+      shouldIgnoreSubscriptionStatus: false,
+      presentationCondition: .checkPrimarySubscription
+    )
+    XCTAssertTrue(outcome)
+  }
+}


### PR DESCRIPTION
## Changes in this pull request

Handles to `presentationCondition` sent in the response. Extracted logic to handle that into logic controller with tests. This defaults to `checkPrimarySubscription` if an unknown enum value is given. Only downside to this is that the response has to be loaded before we can stop the execution of presentation, but most things are preloaded anyway.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
