### PR TITLE
Feature/fix reset on bg thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `Paywall`. Also see the [releases](https://github.com/superwall-me/paywall-ios/releases) on GitHub.
 
+## 2.5.3
+
+### Fixes
+
+- Fixes a bug where `Paywall.reset()` couldn't be called on a background thread.
+
+
 ## 2.5.2
 
 ### Fixes 

--- a/Paywall.podspec
+++ b/Paywall.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "Paywall"
-    s.version      = "2.5.2"
+    s.version      = "2.5.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Sources/Paywall/Misc/Constants.swift
+++ b/Sources/Paywall/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-2.5.2
+2.5.3
 """

--- a/Sources/Paywall/Paywall/Paywall Manager/PaywallCache.swift
+++ b/Sources/Paywall/Paywall/Paywall Manager/PaywallCache.swift
@@ -34,9 +34,11 @@ final class PaywallCache {
   }
 
   func clearCache() {
-    // don't remove the reference to a presented paywall
-    for viewController in SWPaywallViewController.cache where !viewController.isActive {
-      SWPaywallViewController.cache.remove(viewController)
+    DispatchQueue.main.async {
+      // don't remove the reference to a presented paywall
+      for viewController in SWPaywallViewController.cache where !viewController.isActive {
+        SWPaywallViewController.cache.remove(viewController)
+      }
     }
   }
 }

--- a/Tests/PaywallTests/Paywall/Paywall Manager/PaywallCacheTests.swift
+++ b/Tests/PaywallTests/Paywall/Paywall Manager/PaywallCacheTests.swift
@@ -83,34 +83,36 @@ class PaywallCacheTests: XCTestCase {
 
   func testClearCache() {
     // Given
-    let paywallId1 = "id1"
-    let key1 = PaywallCacheLogic.key(forIdentifier: paywallId1)
-    let paywall1: SWPaywallViewController = .stub()
-      .setting(\.cacheKey, to: key1)
+    DispatchQueue.main.async {
+      let paywallId1 = "id1"
+      let key1 = PaywallCacheLogic.key(forIdentifier: paywallId1)
+      let paywall1: SWPaywallViewController = .stub()
+        .setting(\.cacheKey, to: key1)
 
-    let paywallId2 = "id2"
-    let key2 = PaywallCacheLogic.key(forIdentifier: paywallId2)
-    let paywall2: SWPaywallViewController = .stub()
-      .setting(\.cacheKey, to: key2)
+      let paywallId2 = "id2"
+      let key2 = PaywallCacheLogic.key(forIdentifier: paywallId2)
+      let paywall2: SWPaywallViewController = .stub()
+        .setting(\.cacheKey, to: key2)
 
-    // When
-    SWPaywallViewController.cache.insert(paywall1)
-    SWPaywallViewController.cache.insert(paywall2)
+      // When
+      SWPaywallViewController.cache.insert(paywall1)
+      SWPaywallViewController.cache.insert(paywall2)
 
-    let cachedPaywall1 = paywallCache.getPaywall(withKey: key1)
-    let cachedPaywall2 = paywallCache.getPaywall(withKey: key2)
+      let cachedPaywall1 = self.paywallCache.getPaywall(withKey: key1)
+      let cachedPaywall2 = self.paywallCache.getPaywall(withKey: key2)
 
-    XCTAssertEqual(cachedPaywall1, paywall1)
-    XCTAssertEqual(cachedPaywall2, paywall2)
+      XCTAssertEqual(cachedPaywall1, paywall1)
+      XCTAssertEqual(cachedPaywall2, paywall2)
 
-    paywallCache.clearCache()
+      self.paywallCache.clearCache()
 
-    // Then
-    let nilPaywall1 = paywallCache.getPaywall(withKey: key1)
-    let nilPaywall2 = paywallCache.getPaywall(withKey: key2)
+      // Then
+      let nilPaywall1 = self.paywallCache.getPaywall(withKey: key1)
+      let nilPaywall2 = self.paywallCache.getPaywall(withKey: key2)
 
-    XCTAssertNil(nilPaywall1)
-    XCTAssertNil(nilPaywall2)
+      XCTAssertNil(nilPaywall1)
+      XCTAssertNil(nilPaywall2)
+    }
   }
 
   func testViewControllers() {


### PR DESCRIPTION
## Changes in this pull request

- Wrapped a call to cleaning the cache in a `DispatchQueue.main.async` block. This was causing an issue when calling `Paywall.reset()` from a background thread.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
