### PR TITLE
Hotfix/disable preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The changelog for `Paywall`. Also see the [releases](https://github.com/superwall-me/paywall-ios/releases) on GitHub.
 
+## 2.5.5
+
+### Fixes
+
+- Fixes a crash when all variants of a campaign rule are set to 0%.
+
+### Enhancements
+
+- Adds ablity to disable the preloading of paywalls from specific triggers via config.
+
+---
+
 ## 2.5.4
 
 ### Fixes

--- a/Paywall.podspec
+++ b/Paywall.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "Paywall"
-    s.version      = "2.5.4"
+    s.version      = "2.5.5"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Sources/Paywall/Misc/Constants.swift
+++ b/Sources/Paywall/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-2.5.4
+2.5.5
 """

--- a/Sources/Paywall/Models/Config/Config.swift
+++ b/Sources/Paywall/Models/Config/Config.swift
@@ -15,6 +15,7 @@ struct Config: Decodable {
   var locales: Set<String>
   var appSessionTimeout: Milliseconds
   var featureFlags: FeatureFlags
+  var preloadingDisabled: PreloadingDisabled
 
   enum CodingKeys: String, CodingKey {
     case triggers = "triggerOptions"
@@ -24,6 +25,7 @@ struct Config: Decodable {
     case localization
     case appSessionTimeout = "appSessionTimeoutMs"
     case featureFlags = "toggles"
+    case preloadingDisabled = "disablePreload"
   }
 
   init(from decoder: Decoder) throws {
@@ -35,6 +37,7 @@ struct Config: Decodable {
     postback = try values.decode(PostbackRequest.self, forKey: .postback)
     appSessionTimeout = try values.decode(Milliseconds.self, forKey: .appSessionTimeout)
     featureFlags = try FeatureFlags(from: decoder)
+    preloadingDisabled = try values.decode(PreloadingDisabled.self, forKey: .preloadingDisabled)
 
     let localization = try values.decode(LocalizationConfig.self, forKey: .localization)
     locales = Set(localization.locales.map { $0.locale })
@@ -47,7 +50,8 @@ struct Config: Decodable {
     postback: PostbackRequest,
     locales: Set<String>,
     appSessionTimeout: Milliseconds,
-    featureFlags: FeatureFlags
+    featureFlags: FeatureFlags,
+    preloadingDisabled: PreloadingDisabled
   ) {
     self.triggers = triggers
     self.paywallResponses = paywallResponses
@@ -56,6 +60,7 @@ struct Config: Decodable {
     self.locales = locales
     self.appSessionTimeout = appSessionTimeout
     self.featureFlags = featureFlags
+    self.preloadingDisabled = preloadingDisabled
   }
 }
 
@@ -69,7 +74,8 @@ extension Config: Stubbable {
       postback: .stub(),
       locales: [],
       appSessionTimeout: 3600000,
-      featureFlags: .stub()
+      featureFlags: .stub(),
+      preloadingDisabled: .stub()
     )
   }
 }

--- a/Sources/Paywall/Paywall/Config/ConfigLogic.swift
+++ b/Sources/Paywall/Paywall/Config/ConfigLogic.swift
@@ -134,6 +134,20 @@ enum ConfigLogic {
     )
   }
 
+  /// Removes any triggers whose preloading has been remotely disabled.
+  static func filterTriggers(
+    _ triggers: Set<Trigger>,
+    removing preloadingDisabled: PreloadingDisabled
+  ) -> Set<Trigger> {
+    if preloadingDisabled.all {
+      return []
+    }
+
+    return triggers.filter {
+      !preloadingDisabled.triggers.contains($0.eventName)
+    }
+  }
+
   /// Loops through assignments retrieved from the server to get variants by id.
   /// Returns updated confirmed/unconfirmed assignments to save.
   static func transferAssignmentsFromServerToDisk(
@@ -238,6 +252,7 @@ enum ConfigLogic {
     confirmedAssignments: [Experiment.ID: Experiment.Variant],
     unconfirmedAssignments: [Experiment.ID: Experiment.Variant]
   ) -> Set<String> {
+
     let mergedAssignments = confirmedAssignments.merging(unconfirmedAssignments)
     let groupedTriggerRules = getRulesPerTriggerGroup(from: triggers)
     let triggerExperimentIds = groupedTriggerRules.flatMap { $0.map { $0.experiment.id } }

--- a/Sources/Paywall/Paywall/Config/ConfigLogic.swift
+++ b/Sources/Paywall/Paywall/Config/ConfigLogic.swift
@@ -41,6 +41,19 @@ enum ConfigLogic {
       partialResult + variant.percentage
     }
 
+    // Something went wrong on the dashboard, where all variants
+    // have 0% set. Choose a random one.
+    if variantSum == 0 {
+      // Choose a random variant
+      let randomVariantIndex = randomiser(0..<variants.count)
+      let variant = variants[randomVariantIndex]
+      return .init(
+        id: variant.id,
+        type: variant.type,
+        paywallId: variant.paywallId
+      )
+    }
+
     // Choose a random percentage e.g. 21
     let randomPercentage = randomiser(0..<variantSum)
 

--- a/Sources/Paywall/Paywall/Config/ConfigManager.swift
+++ b/Sources/Paywall/Paywall/Config/ConfigManager.swift
@@ -175,7 +175,14 @@ class ConfigManager {
   }
 
   private func getAllActiveTreatmentPaywallIds() -> Set<String> {
-    guard let triggers = config?.triggers else {
+    guard let config = config else {
+      return []
+    }
+    let triggers = ConfigLogic.filterTriggers(
+      config.triggers,
+      removing: config.preloadingDisabled
+    )
+    if triggers.isEmpty {
       return []
     }
     let confirmedAssignments = storage.getConfirmedAssignments()
@@ -187,6 +194,16 @@ class ConfigManager {
   }
 
   private func getTreatmentPaywallIds(from triggers: Set<Trigger>) -> Set<String> {
+    guard let config = config else {
+      return []
+    }
+    let preloadableTriggers = ConfigLogic.filterTriggers(
+      triggers,
+      removing: config.preloadingDisabled
+    )
+    if preloadableTriggers.isEmpty {
+      return []
+    }
     let confirmedAssignments = storage.getConfirmedAssignments()
     return ConfigLogic.getActiveTreatmentPaywallIds(
       forTriggers: triggers,
@@ -245,8 +262,8 @@ class ConfigManager {
       handlePreloadPaywallsPreConfig(forTriggers: triggerNames)
       return
     }
-    let triggersToPreload = config.triggers.filter { triggerNames.contains($0.eventName) }
-    let triggerPaywallIdentifiers = getTreatmentPaywallIds(from: triggersToPreload)
+    let triggers = config.triggers.filter { triggerNames.contains($0.eventName) }
+    let triggerPaywallIdentifiers = getTreatmentPaywallIds(from: triggers)
     preloadPaywalls(withIdentifiers: triggerPaywallIdentifiers)
   }
 

--- a/Sources/Paywall/Paywall/Config/PreloadingDisabled.swift
+++ b/Sources/Paywall/Paywall/Config/PreloadingDisabled.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 24/11/2022.
+//
+
+import Foundation
+
+struct PreloadingDisabled: Codable {
+  let all: Bool
+  let triggers: Set<String>
+}
+
+// MARK: - Stubbable
+
+extension PreloadingDisabled: Stubbable {
+  static func stub() -> PreloadingDisabled {
+    return PreloadingDisabled(
+      all: false,
+      triggers: []
+    )
+  }
+}

--- a/Sources/Paywall/Paywall/Paywall.swift
+++ b/Sources/Paywall/Paywall/Paywall.swift
@@ -30,7 +30,6 @@ public final class Paywall: NSObject {
   /// The ``PaywallInfo`` object stored from the latest paywall that was dismissed.
   var latestDismissedPaywallInfo: PaywallInfo?
 
-
   /// The current user's id. It shouldn't ever be `nil` since Superwall assigns an anonymous user id and caches it to disk if one isn't provided.
   public static var userId: String? {
     // Technically Storage.shared.userId is an optional value

--- a/Tests/PaywallTests/Models/Config/ConfigResponseTests.swift
+++ b/Tests/PaywallTests/Models/Config/ConfigResponseTests.swift
@@ -410,6 +410,10 @@ let response = #"""
     "dns_resolution": [{
       "hostname": "www.fitnessai.com"
     }]
+  },
+  "disable_preload": {
+    "all": false,
+    "triggers": []
   }
 }
 """#

--- a/Tests/PaywallTests/Paywall/Config/ConfigLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Config/ConfigLogicTests.swift
@@ -37,6 +37,26 @@ final class ConfigLogicTests: XCTestCase {
     }
   }
 
+  func test_chooseVariant_manyVariants_zeroSum() {
+    do {
+      let options: [VariantOption] = [
+        .stub()
+        .setting(\.percentage, to: 0),
+        .stub()
+        .setting(\.percentage, to: 0)
+      ]
+      let variant = try ConfigLogic.chooseVariant(
+        from: options,
+        randomiser: { range in
+          // Force choosing the first variant
+          return 0
+        }
+      )
+    } catch {
+      XCTFail("Shouldn't fail")
+    }
+  }
+
   func test_chooseVariant_oneActiveVariant_chooseFirst() {
     do {
       let options: [VariantOption] = [

--- a/Tests/PaywallTests/Paywall/Config/ConfigLogicTests.swift
+++ b/Tests/PaywallTests/Paywall/Config/ConfigLogicTests.swift
@@ -845,4 +845,67 @@ final class ConfigLogicTests: XCTestCase {
     )
     XCTAssertEqual(ids, [paywallId1])
   }
+
+  // MARK: - Filter Triggers
+
+  func test_filterTriggers_noTriggers() {
+    let disabled = PreloadingDisabled(
+      all: true,
+      triggers: ["app_open"]
+    )
+    let triggers = ConfigLogic.filterTriggers(
+      [],
+      removing: disabled
+    )
+    XCTAssertTrue(triggers.isEmpty)
+  }
+
+  func test_filterTriggers_disableAll() {
+    let disabled = PreloadingDisabled(
+      all: true,
+      triggers: []
+    )
+    let triggers: Set<Trigger > = [
+      Trigger(eventName: "app_open", rules: []),
+      Trigger(eventName: "campaign_trigger", rules: [.stub()])
+    ]
+    let filteredTriggers = ConfigLogic.filterTriggers(
+      triggers,
+      removing: disabled
+    )
+    XCTAssertTrue(filteredTriggers.isEmpty)
+  }
+
+  func test_filterTriggers_disableSome() {
+    let disabled = PreloadingDisabled(
+      all: false,
+      triggers: ["app_open"]
+    )
+    let triggers: Set<Trigger > = [
+      Trigger(eventName: "app_open", rules: []),
+      Trigger(eventName: "campaign_trigger", rules: [.stub()])
+    ]
+    let filteredTriggers = ConfigLogic.filterTriggers(
+      triggers,
+      removing: disabled
+    )
+    XCTAssertEqual(filteredTriggers.count, 1)
+    XCTAssertEqual(filteredTriggers.first!.eventName, "campaign_trigger")
+  }
+
+  func test_filterTriggers_disableNone() {
+    let disabled = PreloadingDisabled(
+      all: false,
+      triggers: []
+    )
+    let triggers: Set<Trigger > = [
+      Trigger(eventName: "app_open", rules: []),
+      Trigger(eventName: "campaign_trigger", rules: [.stub()])
+    ]
+    let filteredTriggers = ConfigLogic.filterTriggers(
+      triggers,
+      removing: disabled
+    )
+    XCTAssertEqual(filteredTriggers.count, 2)
+  }
 }


### PR DESCRIPTION
## Changes in this pull request

- Disables preloading for any triggers whose preloading has been disabled via config.
- Bugfix for when all variants on the dashboard have 0% - it now chooses one of those at random with equal percentage.
- Added and updated tests for logic.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
