### PR TITLE
Feature/event privacy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,5 +7,6 @@ Issue fixed: #
 - [ ] All tests pass. Demo project builds and runs.
 - [ ] I added tests, an experiment, or detailed why my change isn't tested.
 - [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
+- [ ] I have run `swiftlint` in the main directory and fixed any issues.
 - [ ] I have updated the SDK documentation as well as the online docs.
 - [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `Paywall`. Also see the [releases](https://github.com/superwall-me/paywall-ios/releases) on GitHub.
 
+## 2.5.7
+
+### Enhancements
+
+- Adds a data privacy `PaywallOption` called `isTrackedUserDataCollected`. When `false`, this prevents non-Superwall events and properties from being sent back to the superwall servers.
+
 ## 2.5.6
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 
 - Fixes a bug that prevented the correct calculation of a new app session.
 - Fixes missing loading times of the webview and products.
+- Adds OSX version to podspec.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 ### Fixes
 
 - Fixes a bug that prevented the correct calculation of a new app session.
+- Fixes missing loading and fail times of the webview and products.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 
 ### Enhancements
 
-- Adds a data privacy `PaywallOption` called `isTrackedUserDataCollected`. When `false`, this prevents non-Superwall events and properties from being sent back to the superwall servers.
+- Adds a data privacy `PaywallOption` called `isExternalDataCollectionEnabled`. When `false`, this prevents non-Superwall events and properties from being sent back to the superwall servers.
 
 ## 2.5.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 
 ### Enhancements
 
-- Adds a data privacy `PaywallOption` called `isExternalDataCollectionEnabled`. When `false`, this prevents non-Superwall events and properties from being sent back to the superwall servers.
+- Adds `isExternalDataCollectionEnabled` data privacy `PaywallOption`. When `false`, prevents non-Superwall events and properties from being sent back to the superwall servers.
 
 ## 2.5.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 ### Fixes
 
 - Fixes a bug that prevented the correct calculation of a new app session.
-- Fixes missing loading and fail times of the webview and products.
+- Fixes missing loading times of the webview and products.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 
 - Adds `isExternalDataCollectionEnabled` data privacy `PaywallOption`. When `false`, prevents non-Superwall events and properties from being sent back to the superwall servers.
 
+### Fixes
+
+- Fixes a bug that prevented the correct calculation of a new app session.
+
+---
+
 ## 2.5.6
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `Paywall`. Also see the [releases](https://github.com/superwal
 ### Enhancements
 
 - Adds `isExternalDataCollectionEnabled` data privacy `PaywallOption`. When `false`, prevents non-Superwall events and properties from being sent back to the superwall servers.
+- Adds an `X-Is-Sandbox` header to all requests such that sandbox data doesn't affect your production analytics on superwall.com.
 
 ### Fixes
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Jake Mor
+Copyright (c) 2023 Nest22
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Paywall.podspec
+++ b/Paywall.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 	s.license      =  { :type => 'MIT', :text => <<-LICENSE
 		MIT License
 
-		Copyright (c) 2022 Superwall
+		Copyright (c) 2023 Superwall
 
 		Permission is hereby granted, free of charge, to any person obtaining a copy
 		of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
 	s.documentation_url = "https://docs.superwall.com/"
 	s.swift_versions = ['5.5']
 	s.ios.deployment_target = '11.2'
+  s.osx.deployment_target = '10.12'
 	s.requires_arc = true
 
   s.source_files  = "Sources/**/*.{swift}"

--- a/Paywall.podspec
+++ b/Paywall.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "Paywall"
-    s.version      = "2.5.6"
+    s.version      = "2.5.7"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Sources/Paywall/App Session/AppSessionLogic.swift
+++ b/Sources/Paywall/App Session/AppSessionLogic.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Yusuf Tör on 04/05/2022.
 //
@@ -12,21 +12,29 @@ enum AppSessionLogic {
   ///
   /// - Parameters:
   ///   - lastAppClose: The date when the app was last closed.
-  ///   - timeout: The timeout for the session, as defined by the config, in milliseconds.
+  ///   - timeout: The timeout for the session, as defined by the config, in milliseconds. By default, this value is 1 hour.
   static func didStartNewSession(
     _ lastAppClose: Date?,
     withSessionTimeout timeout: Milliseconds?
   ) -> Bool {
-    let anHourAgo = 3600000.0
-    let timeout = timeout ?? anHourAgo
+    // Set the timeout value as provided, or with a default of 1 hour.
+    let timeout = timeout ?? 3600000.0
 
-    let delta: TimeInterval
-    if let lastAppClose = lastAppClose {
-      delta = -lastAppClose.timeIntervalSinceNow
-    } else {
-      delta = timeout + 1
+    // If the app has never been closed, we've started a new session.
+    guard let lastAppClose = lastAppClose else {
+      return true
     }
 
-    return delta > timeout
+    // Determine the elapsed duration between now and the last app close (in milliseconds).
+    let elapsedDuration = -lastAppClose.timeIntervalSinceNowInMilliseconds
+
+    // If it's been longer than the provided session timeout duration, we should consider this the start of a new session.
+    return elapsedDuration > timeout
+  }
+}
+
+extension Date {
+  var timeIntervalSinceNowInMilliseconds: Milliseconds {
+    return timeIntervalSinceNow * 1000
   }
 }

--- a/Sources/Paywall/Misc/Constants.swift
+++ b/Sources/Paywall/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-2.5.6
+2.5.7
 """

--- a/Sources/Paywall/Models/Paywall/PaywallInfo.swift
+++ b/Sources/Paywall/Models/Paywall/PaywallInfo.swift
@@ -172,7 +172,7 @@ public final class PaywallInfo: NSObject {
       "paywall_webview_load_duration": webViewLoadDuration as Any,
       "paywall_products_load_start_time": productsLoadStartTime as Any,
       "paywall_products_load_complete_time": productsLoadCompleteTime as Any,
-      "paywall_products_load_fail_time": productsLoadCompleteTime as Any,
+      "paywall_products_load_fail_time": productsLoadFailTime as Any,
       "paywall_products_load_duration": productsLoadDuration as Any
     ]
 

--- a/Sources/Paywall/Network/DeviceHelper.swift
+++ b/Sources/Paywall/Network/DeviceHelper.swift
@@ -110,6 +110,20 @@ class DeviceHelper {
     return Bundle.main.bundleIdentifier ?? ""
   }()
 
+  /// Returns true if built with the debug flag, or using TestFlight.
+  let isSandbox: String = {
+    #if DEBUG
+      return "true"
+    #else
+
+    guard let url = Bundle.main.appStoreReceiptURL else {
+      return "false"
+    }
+
+    return "\(url.path.contains("sandboxReceipt"))"
+    #endif
+  }()
+
   private let appInstallDate: Date? = {
     guard let urlToDocumentsFolder = FileManager.default.urls(
       for: .documentDirectory,

--- a/Sources/Paywall/Network/Endpoint.swift
+++ b/Sources/Paywall/Network/Endpoint.swift
@@ -92,6 +92,7 @@ struct Endpoint<Response: Decodable> {
       "X-Request-Id": requestId,
       "X-Bundle-ID": DeviceHelper.shared.bundleId,
       "X-Low-Power-Mode": DeviceHelper.shared.isLowPowerModeEnabled,
+      "X-Is-Sandbox": DeviceHelper.shared.isSandbox,
       "Content-Type": "application/json"
     ]
 

--- a/Sources/Paywall/Paywall/Config/PaywallOptions.swift
+++ b/Sources/Paywall/Paywall/Config/PaywallOptions.swift
@@ -16,6 +16,12 @@ public class PaywallOptions: NSObject {
   /// Haptic feedback occurs when a user purchases or restores a product, opens a URL from the paywall, or closes the paywall.
   public var isHapticFeedbackEnabled = true
 
+  /// Sends non-Superwall tracked events and properties back to the Superwall servers. Defaults to `true`.
+  ///
+  /// Set this to `false` if you want enhanced user privacy. Setting this to `false` will not affect
+  /// your ability to create triggers based on properties.
+  public var isTrackedUserDataCollected = true
+
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
   public struct RestoreFailed {
     /// The title of the alert presented to the user when restoring a transaction fails. Defaults to `No Subscription Found`.

--- a/Sources/Paywall/Paywall/Config/PaywallOptions.swift
+++ b/Sources/Paywall/Paywall/Config/PaywallOptions.swift
@@ -16,11 +16,12 @@ public class PaywallOptions: NSObject {
   /// Haptic feedback occurs when a user purchases or restores a product, opens a URL from the paywall, or closes the paywall.
   public var isHapticFeedbackEnabled = true
 
-  /// Sends non-Superwall tracked events and properties back to the Superwall servers. Defaults to `true`.
+  /// Enables the sending of non-Superwall tracked events and properties back to the Superwall servers.
+  /// Defaults to `true`.
   ///
-  /// Set this to `false` if you want enhanced user privacy. Setting this to `false` will not affect
+  /// Set this to `false` to stop external data collection. This will not affect
   /// your ability to create triggers based on properties.
-  public var isTrackedUserDataCollected = true
+  public var isExternalDataCollectionEnabled = true
 
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
   public struct RestoreFailed {

--- a/Sources/Paywall/Paywall/Events/Internal Tracking/Tracking.swift
+++ b/Sources/Paywall/Paywall/Events/Internal Tracking/Tracking.swift
@@ -46,7 +46,7 @@ extension Paywall {
       parameters: JSON(parameters.eventParams),
       createdAt: eventCreatedAt
     )
-		queue.enqueue(event: eventData.jsonData)
+    queue.enqueue(event: event, jsonData: eventData.jsonData)
     Storage.shared.coreDataManager.saveEventData(eventData)
 
     if event.canImplicitlyTriggerPaywall {

--- a/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
+++ b/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
@@ -61,8 +61,14 @@ final class PaywallManager {
         if cached,
           let identifier = response.identifier,
           let viewController = self.cache.getPaywall(withIdentifier: identifier) {
-          // Set paywall response again incase products have been substituted into paywallResponse.
-          viewController.paywallResponse = response
+          // Set product-related vars again incase products have been substituted into paywall.
+          viewController.paywallResponse.products = response.products
+          viewController.paywallResponse.swProducts = response.swProducts
+          viewController.paywallResponse.isFreeTrialAvailable = response.isFreeTrialAvailable
+          viewController.paywallResponse.productVariables = response.productVariables
+          viewController.paywallResponse.productsLoadFailTime = response.productsLoadFailTime
+          viewController.paywallResponse.productsLoadStartTime = response.productsLoadStartTime
+          viewController.paywallResponse.productsLoadCompleteTime = response.productsLoadCompleteTime
           completion?(.success(viewController))
           return
         }

--- a/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
+++ b/Sources/Paywall/Paywall/Paywall Manager/PaywallManager.swift
@@ -64,8 +64,9 @@ final class PaywallManager {
           // Set product-related vars again incase products have been substituted into paywall.
           viewController.paywallResponse.products = response.products
           viewController.paywallResponse.swProducts = response.swProducts
-          viewController.paywallResponse.isFreeTrialAvailable = response.isFreeTrialAvailable
+          viewController.paywallResponse.variables = response.variables
           viewController.paywallResponse.productVariables = response.productVariables
+          viewController.paywallResponse.isFreeTrialAvailable = response.isFreeTrialAvailable
           viewController.paywallResponse.productsLoadFailTime = response.productsLoadFailTime
           viewController.paywallResponse.productsLoadStartTime = response.productsLoadStartTime
           viewController.paywallResponse.productsLoadCompleteTime = response.productsLoadCompleteTime

--- a/Sources/Paywall/Paywall/Paywall Response/PaywallResponseManager.swift
+++ b/Sources/Paywall/Paywall/Paywall Response/PaywallResponseManager.swift
@@ -252,7 +252,7 @@ final class PaywallResponseManager: NSObject {
       eventData: event
     )
     Paywall.track(productLoadEvent)
-    
+
     // cache the response for later if we haven't substituted products.
     if isNotSubstitutingProducts {
       self.responsesByHash[paywallRequestHash] = .success(response)

--- a/Sources/Paywall/Paywall/Paywall Response/PaywallResponseManager.swift
+++ b/Sources/Paywall/Paywall/Paywall Response/PaywallResponseManager.swift
@@ -173,7 +173,7 @@ final class PaywallResponseManager: NSObject {
 
     let productLoadEvent = SuperwallEvent.PaywallProductsLoad(
       state: .start,
-      paywallInfo: paywallInfo,
+      paywallInfo: response.getPaywallInfo(fromEvent: event),
       eventData: event
     )
     Paywall.track(productLoadEvent)
@@ -239,7 +239,21 @@ final class PaywallResponseManager: NSObject {
       Paywall.isFreeTrialAvailableOverride = nil
     }
 
-      // cache the response for later if we haven't substituted products.
+    response.productsLoadCompleteTime = Date()
+
+    let paywallInfo = response.getPaywallInfo(fromEvent: event)
+    SessionEventsManager.shared.triggerSession.trackProductsLoad(
+      forPaywallId: paywallInfo.id,
+      state: .end
+    )
+    let productLoadEvent = SuperwallEvent.PaywallProductsLoad(
+      state: .complete,
+      paywallInfo: paywallInfo,
+      eventData: event
+    )
+    Paywall.track(productLoadEvent)
+    
+    // cache the response for later if we haven't substituted products.
     if isNotSubstitutingProducts {
       self.responsesByHash[paywallRequestHash] = .success(response)
     }
@@ -255,19 +269,5 @@ final class PaywallResponseManager: NSObject {
 
     // reset the handler cache
     self.handlersByHash.removeValue(forKey: paywallRequestHash)
-
-    response.productsLoadCompleteTime = Date()
-
-    let paywallInfo = response.getPaywallInfo(fromEvent: event)
-    SessionEventsManager.shared.triggerSession.trackProductsLoad(
-      forPaywallId: paywallInfo.id,
-      state: .end
-    )
-    let productLoadEvent = SuperwallEvent.PaywallProductsLoad(
-      state: .complete,
-      paywallInfo: paywallInfo,
-      eventData: event
-    )
-    Paywall.track(productLoadEvent)
   }
 }

--- a/Sources/Paywall/Storage/EventsQueue.swift
+++ b/Sources/Paywall/Storage/EventsQueue.swift
@@ -40,7 +40,7 @@ final class EventsQueue {
   }
 
   func enqueue(event: JSON) {
-    if !Paywall.options.isTrackedUserDataCollected,
+    if !Paywall.options.isExternalDataCollectionEnabled,
       event["parameters"]["$is_standard_event"] == false {
       return
     }

--- a/Sources/Paywall/Storage/EventsQueue.swift
+++ b/Sources/Paywall/Storage/EventsQueue.swift
@@ -40,6 +40,10 @@ final class EventsQueue {
   }
 
   func enqueue(event: JSON) {
+    if !Paywall.options.isTrackedUserDataCollected,
+      event["parameters"]["$is_standard_event"] == false {
+      return
+    }
     serialQueue.async {
       self.elements.append(event)
     }

--- a/Sources/Paywall/Storage/EventsQueue.swift
+++ b/Sources/Paywall/Storage/EventsQueue.swift
@@ -39,14 +39,25 @@ final class EventsQueue {
     )
   }
 
-  func enqueue(event: JSON) {
-    if !Paywall.options.isExternalDataCollectionEnabled,
-      event["parameters"]["$is_standard_event"] == false {
+  func enqueue(event: Trackable, jsonData: JSON) {
+    guard externalDataCollectionAllowed(from: event) else {
       return
     }
     serialQueue.async {
-      self.elements.append(event)
+      self.elements.append(jsonData)
     }
+  }
+
+  private func externalDataCollectionAllowed(from event: Trackable) -> Bool {
+    if Paywall.options.isExternalDataCollectionEnabled {
+      return true
+    }
+    if event is SuperwallEvent.TriggerFire
+      || event is SuperwallEvent.Attributes
+      || event is UserInitiatedEvent.Track {
+      return false
+    }
+    return true
   }
 
   @objc private func flush() {

--- a/Tests/PaywallTests/App Session/AppSessionLogicTests.swift
+++ b/Tests/PaywallTests/App Session/AppSessionLogicTests.swift
@@ -1,6 +1,6 @@
 //
 //  PaywallLogicTests.swift
-//  
+//
 //
 //  Created by Yusuf Tör on 09/03/2022.
 //
@@ -13,7 +13,7 @@ import XCTest
 class AppSessionLogicTests: XCTestCase {
   @available(iOS 13, *)
   func testDidStartNewSession_noTimeout() {
-    let threeHoursAgo = Date().advanced(by: -7200000)
+    let threeHoursAgo = Date().advanced(by: -10800)
     let sessionDidStart = AppSessionLogic.didStartNewSession(
       threeHoursAgo,
       withSessionTimeout: nil
@@ -23,7 +23,7 @@ class AppSessionLogicTests: XCTestCase {
 
   @available(iOS 13, *)
   func testDidStartNewSession_noTimeout_lastAppClosedFiftyMinsAgo() {
-    let fiftyMinsAgo = Date().advanced(by: -3000000)
+    let fiftyMinsAgo = Date().advanced(by: -3000)
     let sessionDidStart = AppSessionLogic.didStartNewSession(
       fiftyMinsAgo,
       withSessionTimeout: nil
@@ -42,7 +42,7 @@ class AppSessionLogicTests: XCTestCase {
 
   @available(iOS 13, *)
   func testDidStartNewSession_lastAppClosedThirtyMinsAgo() {
-    let thirtyMinsAgo = Date().advanced(by: -1800000)
+    let thirtyMinsAgo = Date().advanced(by: -1800)
     let timeout = 3600000.0
     let sessionDidStart = AppSessionLogic.didStartNewSession(
       thirtyMinsAgo,
@@ -50,10 +50,10 @@ class AppSessionLogicTests: XCTestCase {
     )
     XCTAssertFalse(sessionDidStart)
   }
-  
+
   @available(iOS 13, *)
   func testDidStartNewSession_lastAppClosedThreeHoursAgo() {
-    let threeHoursAgo = Date().advanced(by: -7200000)
+    let threeHoursAgo = Date().advanced(by: -10800)
     let timeout = 3600000.0
     let sessionDidStart = AppSessionLogic.didStartNewSession(
       threeHoursAgo,


### PR DESCRIPTION
## Changes in this pull request

- Adds `isExternalDataCollectionEnabled` data privacy `PaywallOption`. When `false`, prevents non-Superwall events and properties from being sent back to the superwall servers.
- Adds an `X-Is-Sandbox` header to all requests such that sandbox data doesn't affect your production analytics on superwall.com.
- Fixes a bug that prevented the correct calculation of a new app session.
- Fixes missing loading times of the webview and products.
- Updates version to 2.5.7
- Adds OSX version to podspec.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
