### PR TITLE
fix: webview refresh on terminate

### DIFF
--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -734,6 +734,7 @@ enum InternalSuperwallEvent {
       case timeout
       case complete
       case fallback
+      case processTerminated
     }
     let state: State
 
@@ -749,6 +750,8 @@ enum InternalSuperwallEvent {
         return .paywallWebviewLoadComplete(paywallInfo: paywallInfo)
       case .fallback:
         return .paywallWebviewLoadFallback(paywallInfo: paywallInfo)
+      case .processTerminated:
+        return .paywallWebviewProcessTerminated(paywallInfo: paywallInfo)
       }
     }
     let paywallInfo: PaywallInfo

--- a/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEvent.swift
@@ -131,6 +131,9 @@ public enum SuperwallEvent {
   /// When a paywall's website completes loading.
   case paywallWebviewLoadFallback(paywallInfo: PaywallInfo)
 
+  /// When the paywall's web view content process terminates.
+  case paywallWebviewProcessTerminated(paywallInfo: PaywallInfo)
+
   /// When the request to load the paywall's products started.
   case paywallProductsLoadStart(triggeredPlacementName: String?, paywallInfo: PaywallInfo)
 
@@ -346,6 +349,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .paywallWebviewLoadTimeout)
     case .paywallWebviewLoadFallback:
       return .init(objcEvent: .paywallWebviewLoadFallback)
+    case .paywallWebviewProcessTerminated:
+      return .init(objcEvent: .paywallWebviewProcessTerminated)
     case .paywallProductsLoadStart:
       return .init(objcEvent: .paywallProductsLoadStart)
     case .paywallProductsLoadFail:

--- a/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Placement/SuperwallEventObjc.swift
@@ -119,6 +119,9 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the loading of a paywall's website falls back to a different CDN.
   case paywallWebviewLoadFallback
 
+  /// When the paywall's web view content process terminates.
+  case paywallWebviewProcessTerminated
+
   /// When the request to load the paywall's products started.
   case paywallProductsLoadStart
 
@@ -289,6 +292,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "paywallWebviewLoad_timeout"
     case .paywallWebviewLoadFallback:
       return "paywallWebviewLoad_fallback"
+    case .paywallWebviewProcessTerminated:
+      return "paywallWebviewLoad_processTerminated"
     case .paywallProductsLoadStart:
       return "paywallProductsLoad_start"
     case .paywallProductsLoadFail:

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/SWWebView.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/SWWebView.swift
@@ -239,5 +239,17 @@ extension SWWebView: WKNavigationDelegate {
 
   func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
     webView.reload()
+
+    Task {
+      guard let paywallInfo = delegate?.info else {
+        return
+      }
+
+      let processTerminated = InternalSuperwallEvent.PaywallWebviewLoad(
+        state: .processTerminated,
+        paywallInfo: paywallInfo
+      )
+      await Superwall.shared.track(processTerminated)
+    }
   }
 }


### PR DESCRIPTION
## Changes in this pull request

- adds automatic webview refreshing if the process terminates
- adds new SuperwallEvent `paywallWebviewLoad_processTerminated` and logs when the webview process terminates 
- resolves SW-4129

### Checklist

- [X] All unit tests pass.
- [X] All UI tests pass.
- [X] Demo project builds and runs.
- [X] I added/updated tests or detailed why my change isn't tested.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have run `swiftlint` in the main directory and fixed any issues.
- [X] I have updated the SDK documentation as well as the online docs.
- [X] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
