### PR TITLE
Fix didRedeemLink not called when paywall is dismissed

### DIFF
--- a/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
+++ b/Sources/SuperwallKit/Web/WebEntitlementRedeemer.swift
@@ -337,7 +337,7 @@ actor WebEntitlementRedeemer {
       await self.delegate.didRedeemLink(result: codeResult)
     }
 
-    if showConfirmation {
+    if showConfirmation, let paywallVc = superwall.paywallViewController {
       let title = LocalizationLogic.localizedBundle().localizedString(
         forKey: "purchase_success_title",
         value: nil,
@@ -354,7 +354,7 @@ actor WebEntitlementRedeemer {
         table: nil
       )
 
-      await superwall.paywallViewController?.presentAlert(
+      await paywallVc.presentAlert(
         title: title,
         message: message,
         closeActionTitle: closeActionTitle,


### PR DESCRIPTION
## Summary

- Fixes `didRedeemLink` delegate method not being called when `shouldShowWebPurchaseConfirmationAlert` is `true` but the paywall has already been dismissed

## Problem

When a web checkout redemption completes, the SDK tries to show a confirmation alert via `paywallViewController?.presentAlert()`. If the paywall VC is `nil` (already dismissed), the optional chaining causes the alert to silently not present, and the `onClose` callback (which contains `didRedeemLink`) never fires.

This causes `willRedeemLink` to be called but `didRedeemLink` to never be called in scenarios where:
- The paywall auto-dismisses before redemption completes
- The user dismisses the paywall while web checkout is in progress
- The app handles a redemption deep link when no paywall is visible

## Solution

Changed the condition from:
```swift
if showConfirmation {
  await superwall.paywallViewController?.presentAlert(...)
}
```

To:
```swift
if showConfirmation, let paywallVc = superwall.paywallViewController {
  await paywallVc.presentAlert(...)
} else {
  await afterRedeem()
}
```

This ensures `didRedeemLink` is always called regardless of paywall state.

## Test plan

- [ ] Verify `didRedeemLink` is called when paywall is visible and alert shows
- [ ] Verify `didRedeemLink` is called when paywall is dismissed before redemption completes
- [ ] Verify `didRedeemLink` is called when `shouldShowWebPurchaseConfirmationAlert` is `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)