### PR TITLE
fix crash in SwiftyJSON dictionary unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
+- Fixes a crash in `SwiftyJSON.swift` caused by a race condition when accessing JSON dictionaries concurrently.
 - Fixes issue returning the `PurchaseResult` from `Superwall.shared.purchase(_:)` when using StoreKit 1 inside a `PurchaseController`.
 - Fixes `handleDeepLink` returning true for non-Superwall URLs when called before configuration completes.
 

--- a/Sources/SuperwallKit/Misc/SwiftyJSON.swift
+++ b/Sources/SuperwallKit/Misc/SwiftyJSON.swift
@@ -263,11 +263,12 @@ private func unwrap(_ object: Any) -> Any {
   case let array as [Any]:
     return array.map(unwrap)
   case let dictionary as [String: Any]:
-    var dictionary = dictionary
-    dictionary.forEach { pair in
-      dictionary[pair.key] = unwrap(pair.value)
+    var result: [String: Any] = [:]
+    result.reserveCapacity(dictionary.count)
+    for (key, value) in dictionary {
+      result[key] = unwrap(value)
     }
-    return dictionary
+    return result
   default:
     return object
   }


### PR DESCRIPTION
## Changes in this pull request

- Fixes a crash in `SwiftyJSON.swift:267` caused by a race condition when multiple threads access JSON dictionaries concurrently. The `unwrap` function was mutating a dictionary while iterating over it with `forEach`, which caused a crash during Copy-on-Write when accessed from multiple threads. The fix creates a new dictionary instead of mutating during iteration.

### Checklist

- [x] All unit tests pass.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
