### PR TITLE
4.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.12.11
+
+### Enhancements
+
+- Adds `appstackId` as an `IntegrationAttribute`.
+
 ## 4.12.10
 
 ### Enhancements

--- a/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
@@ -70,6 +70,9 @@ public enum IntegrationAttribute: Int {
 
   /// The Customer.io person's identifier (`id)`.
   case customerioId
+
+  /// The Appstack identifier.
+  case appstackId
 }
 
 // MARK: - CustomStringConvertible
@@ -118,6 +121,8 @@ extension IntegrationAttribute: CustomStringConvertible {
       return "posthogUserId"
     case .customerioId:
       return "customerioId"
+    case .appstackId:
+      return "appstackId"
     }
   }
 }

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.12.10
+4.12.11
 """

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.12.10"
+  s.version      = "4.12.11"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AttributionTests.swift
@@ -347,7 +347,8 @@ struct AttributionTests {
         .kochavaDeviceId: "kochava-device-id",
         .tenjinId: "tenjin-id",
         .posthogUserId: "posthog-user-id",
-        .customerioId: "customerio-id"
+        .customerioId: "customerio-id",
+        .appstackId: "appstack-id"
       ]
       
       // When
@@ -376,6 +377,7 @@ struct AttributionTests {
       #expect(storedProps["tenjinId"] as? String == "tenjin-id")
       #expect(storedProps["posthogUserId"] as? String == "posthog-user-id")
       #expect(storedProps["customerioId"] as? String == "customerio-id")
+      #expect(storedProps["appstackId"] as? String == "appstack-id")
     }
   }
 


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds `appstackId` as an `IntegrationAttribute`.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs on iOS.
- [x] Demo project builds and runs on Mac Catalyst.
- [x] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `appstackId` as a new `IntegrationAttribute` to support Appstack integration tracking.

- Added `.appstackId` case to the `IntegrationAttribute` enum with proper documentation
- Implemented `CustomStringConvertible` conformance returning "appstackId"
- Updated version to 4.12.11 across all required files (`Constants.swift`, `SuperwallKit.podspec`, `CHANGELOG.md`)
- Added comprehensive test coverage in the all-attributes test case
- Copyright year updated to 2026 in podspec

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and follows established patterns. The new `appstackId` attribute is added consistently to the enum, string representation, and tests. All version numbers are correctly updated across the three required files. No logic changes or potential breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift | Added `appstackId` case to enum and its string representation - implementation is consistent with existing patterns |
| Tests/SuperwallKitTests/Analytics/Attribution/AttributionTests.swift | Added test coverage for `appstackId` attribute in comprehensive integration test - properly validates new attribute |
| Sources/SuperwallKit/Misc/Constants.swift | Bumped SDK version from 4.12.10 to 4.12.11 on correct line (21) as required |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant SW as Superwall
    participant AF as AttributionFetcher
    participant Storage as Storage/UserAttributes

    Dev->>SW: setIntegrationAttribute(.appstackId, "appstack-id")
    SW->>AF: Check if appTransactionId exists
    
    alt appTransactionId exists
        AF->>AF: Convert IntegrationAttribute.appstackId to "appstackId" string
        AF->>Storage: Store attribute with key "appstackId"
        AF->>Storage: Set as user attribute
        Note over AF,Storage: Immediate attribution
    else appTransactionId not available
        AF->>AF: Enqueue attributes for later
        Note over AF: Will be processed when appTransactionId becomes available
    end
    
    Storage-->>Dev: Integration attribute stored and ready for tracking
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->