### PR TITLE
feat: add localResources API for local paywall assets

### DIFF
--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -82,73 +82,24 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
 
   // MARK: - File Loading
 
-  /// Loads a file from the app bundle based on the URL path
-  /// - Parameter url: The swlocal:// URL
+  /// Loads a file from `Superwall.shared.localResources` based on the URL host (the localResourceId).
+  /// - Parameter url: The swlocal:// URL where the host is the localResourceId
   /// - Returns: Tuple of file data and MIME type
   private func loadFile(from url: URL) throws -> (Data, String) {
-    // URL format: swlocal://path/to/file.ext
-    // The host + path together form the file path
     guard let host = url.host else {
       throw FileError.invalidURL
     }
 
-    // Combine host and path to get full file path
-    // e.g., swlocal://design/video.mp4 -> design/video.mp4
-    let filePath: String
-    if url.path.isEmpty {
-      filePath = host
-    } else {
-      filePath = host + url.path
+    guard let localURL = Superwall.shared.localResources[host] else {
+      throw FileError.fileNotFound(host)
     }
 
-    guard let fileURL = findInBundle(path: filePath) else {
-      throw FileError.fileNotFound(filePath)
+    guard let data = try? Data(contentsOf: localURL) else {
+      throw FileError.unableToReadFile(localURL.path)
     }
 
-    guard let data = try? Data(contentsOf: fileURL) else {
-      throw FileError.unableToReadFile(filePath)
-    }
-
-    let mimeType = self.mimeType(for: fileURL.pathExtension)
-
+    let mimeType = self.mimeType(for: localURL.pathExtension)
     return (data, mimeType)
-  }
-
-  /// Attempts to find a file in the bundle
-  private func findInBundle(path: String) -> URL? {
-    // Try with the path as-is in the resource path
-    if let resourcePath = Bundle.main.resourcePath {
-      let fullPath = (resourcePath as NSString).appendingPathComponent(path)
-      if FileManager.default.fileExists(atPath: fullPath) {
-        return URL(fileURLWithPath: fullPath)
-      }
-    }
-
-    // Try using url(forResource:withExtension:)
-    let nsPath = path as NSString
-    let name = nsPath.deletingPathExtension
-    let ext = nsPath.pathExtension
-
-    if !ext.isEmpty, let url = Bundle.main.url(forResource: name, withExtension: ext) {
-      return url
-    }
-
-    // Try with subdirectory
-    let directory = (path as NSString).deletingLastPathComponent
-    let filename = (path as NSString).lastPathComponent
-    let fileNameWithoutExt = (filename as NSString).deletingPathExtension
-    let fileExt = (filename as NSString).pathExtension
-
-    if !directory.isEmpty,
-       let url = Bundle.main.url(
-        forResource: fileNameWithoutExt,
-        withExtension: fileExt,
-        subdirectory: directory
-       ) {
-      return url
-    }
-
-    return nil
   }
 
   // MARK: - MIME Type Detection

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -10,6 +10,21 @@ import StoreKit
 @objcMembers
 public final class Superwall: NSObject, ObservableObject {
   // MARK: - Public Properties
+
+  /// A mapping of local resource IDs to local file URLs.
+  ///
+  /// Use this to serve paywall assets (images, videos, Lottie animations) from local files
+  /// instead of fetching them over the network. When a paywall references a `localResourceId`,
+  /// the SDK will look up the corresponding URL in this dictionary.
+  ///
+  /// ```swift
+  /// Superwall.shared.localResources = [
+  ///   "hero-video": Bundle.main.url(forResource: "onboarding", withExtension: "mp4")!,
+  ///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!
+  /// ]
+  /// ```
+  public var localResources: [String: URL] = [:]
+
   /// The delegate that handles Superwall lifecycle events.
   public var delegate: SuperwallDelegate? {
     get {


### PR DESCRIPTION
## Summary
- Adds `Superwall.shared.localResources: [String: URL]` public property for mapping local resource IDs to local file URLs
- Simplifies `LocalFileSchemeHandler.loadFile` to look up resources from the `localResources` dictionary instead of searching the bundle
- When a paywall references `swlocal://{localResourceId}`, the scheme handler serves the file from the mapped URL
- If the resource ID isn't registered, the handler errors and the webview's HTML-level fallback (`onerror`/`<source>`) loads the remote URL

## Test plan
- [ ] Register local resources → load paywall → verify local file served via scheme handler
- [ ] Don't register mapping → verify fallback to remote URL via onerror/source
- [ ] Register mapping with bad file path → verify error + fallback

Companion PR: https://github.com/superwall/paywall-next/pull/2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a public `Superwall.shared.localResources: [String: URL]` dictionary so apps can register local paywall assets by ID. The `LocalFileSchemeHandler` is updated to resolve `swlocal://{id}` requests via that dictionary rather than attempting to locate assets in the bundle; if the ID isn’t registered (or the URL is invalid), the handler returns an error and the paywall’s HTML-level fallback loads a remote asset.

This fits into the existing paywall webview flow by keeping `swlocal://` resolution centralized in the scheme handler while letting the host app control where local assets live on disk.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge; main fix is documentation correctness in scheme handler.
- The code change is small and localized, but the top-level `LocalFileSchemeHandler` docs/examples are now incorrect relative to the new host-based lookup and will reliably mislead integrators into using a URL format that can never resolve via `localResources`. No other clear runtime/compilation issues were identified in the changed files.
- Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift | Switched swlocal:// resolution from bundle path lookup to `Superwall.shared.localResources[host]` URL mapping; file header docs/examples are now inconsistent with the new host-based format and should be updated to avoid guaranteed lookup failures. |
| Sources/SuperwallKit/Superwall.swift | Added public `localResources: [String: URL]` property for registering local paywall assets; straightforward API addition, but it’s a mutable global dictionary with no thread-safety guarantees (callers should mutate before paywall presentation). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant App as Host App
  participant SW as Superwall.shared
  participant WC as PaywallViewController
  participant WV as WKWebView
  participant SH as LocalFileSchemeHandler
  participant FS as Local File URL

  App->>SW: set localResources[id] = fileURL
  App->>SW: present paywall (existing flow)
  SW->>WC: create/configure paywall webview
  WC->>WV: load paywall HTML
  WV->>SH: request swlocal://{localResourceId}
  SH->>SW: lookup localResources[host]
  alt mapping exists and file readable
    SH->>FS: Data(contentsOf: fileURL)
    SH-->>WV: URLResponse + Data
  else missing mapping / read failure
    SH-->>WV: didFailWithError
    WV-->>WV: HTML onerror/<source> loads remote URL
  end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=ae0afcf7-0b55-482b-9764-29f361e46714))

<!-- /greptile_comment -->