### PR TITLE
Fix redeem auth race during startup

### DIFF
--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -48,11 +48,13 @@ final class DependencyContainer {
   let paywallArchiveManager = PaywallArchiveManager()
 
   init(
+    apiKey: String = "",
     purchaseController controller: PurchaseController? = nil,
     options: SuperwallOptions? = nil
   ) {
     delegateAdapter = SuperwallDelegateAdapter()
     storage = Storage(factory: self)
+    storage.configure(apiKey: apiKey)
     entitlementsInfo = EntitlementsInfo(
       storage: storage,
       delegateAdapter: delegateAdapter

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -413,26 +413,13 @@ public final class Superwall: NSObject, ObservableObject {
     super.init()
   }
 
-  static func makeDependencyContainer(
-    apiKey: String,
-    purchaseController: PurchaseController? = nil,
-    options: SuperwallOptions? = nil
-  ) -> DependencyContainer {
-    let dependencyContainer = DependencyContainer(
-      purchaseController: purchaseController,
-      options: options
-    )
-    dependencyContainer.storage.configure(apiKey: apiKey)
-    return dependencyContainer
-  }
-
   private convenience init(
     apiKey: String,
     purchaseController: PurchaseController? = nil,
     options: SuperwallOptions? = nil,
     completion: (() -> Void)?
   ) {
-    let dependencyContainer = Self.makeDependencyContainer(
+    let dependencyContainer = DependencyContainer(
       apiKey: apiKey,
       purchaseController: purchaseController,
       options: options

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -376,13 +376,27 @@ public final class Superwall: NSObject, ObservableObject {
     super.init()
   }
 
+  static func makeDependencyContainer(
+    apiKey: String,
+    purchaseController: PurchaseController? = nil,
+    options: SuperwallOptions? = nil
+  ) -> DependencyContainer {
+    let dependencyContainer = DependencyContainer(
+      purchaseController: purchaseController,
+      options: options
+    )
+    dependencyContainer.storage.configure(apiKey: apiKey)
+    return dependencyContainer
+  }
+
   private convenience init(
     apiKey: String,
     purchaseController: PurchaseController? = nil,
     options: SuperwallOptions? = nil,
     completion: (() -> Void)?
   ) {
-    let dependencyContainer = DependencyContainer(
+    let dependencyContainer = Self.makeDependencyContainer(
+      apiKey: apiKey,
       purchaseController: purchaseController,
       options: options
     )
@@ -406,8 +420,6 @@ public final class Superwall: NSObject, ObservableObject {
           }
         #endif
       }
-
-      dependencyContainer.storage.configure(apiKey: apiKey)
 
       dependencyContainer.storage.recordAppInstall(trackPlacement: track)
 

--- a/Tests/SuperwallKitTests/Storage/StorageTests.swift
+++ b/Tests/SuperwallKitTests/Storage/StorageTests.swift
@@ -6,17 +6,19 @@
 //
 // swiftlint:disable all
 
-import XCTest
 import Testing
 @testable import SuperwallKit
 
-class StorageTests: XCTestCase {
+@Suite
+struct StorageTests {
+  @Test
   func test_makeDependencyContainer_configuresApiKeySynchronously() {
     let dependencyContainer = Superwall.makeDependencyContainer(apiKey: "pk_test_123")
 
-    XCTAssertEqual(dependencyContainer.storage.apiKey, "pk_test_123")
+    #expect(dependencyContainer.storage.apiKey == "pk_test_123")
   }
 
+  @Test
   func test_overwriteAssignments() {
     let dependencyContainer = DependencyContainer()
     let storage = Storage(factory: dependencyContainer)
@@ -35,12 +37,12 @@ class StorageTests: XCTestCase {
     storage.overwriteAssignments(assignments)
 
     let retrievedAssignments = storage.getAssignments()
-    XCTAssertEqual(retrievedAssignments.first, assignments.first)
+    #expect(retrievedAssignments.first == assignments.first)
 
     storage.reset()
 
     let retrievedAssignments2 = storage.getAssignments()
-    XCTAssertTrue(retrievedAssignments2.isEmpty)
+    #expect(retrievedAssignments2.isEmpty)
   }
 }
 

--- a/Tests/SuperwallKitTests/Storage/StorageTests.swift
+++ b/Tests/SuperwallKitTests/Storage/StorageTests.swift
@@ -12,8 +12,8 @@ import Testing
 @Suite
 struct StorageTests {
   @Test
-  func test_makeDependencyContainer_configuresApiKeySynchronously() {
-    let dependencyContainer = Superwall.makeDependencyContainer(apiKey: "pk_test_123")
+  func test_dependencyContainerInit_configuresApiKeySynchronously() {
+    let dependencyContainer = DependencyContainer(apiKey: "pk_test_123")
 
     #expect(dependencyContainer.storage.apiKey == "pk_test_123")
   }

--- a/Tests/SuperwallKitTests/Storage/StorageTests.swift
+++ b/Tests/SuperwallKitTests/Storage/StorageTests.swift
@@ -10,6 +10,12 @@ import XCTest
 @testable import SuperwallKit
 
 class StorageTests: XCTestCase {
+  func test_makeDependencyContainer_configuresApiKeySynchronously() {
+    let dependencyContainer = Superwall.makeDependencyContainer(apiKey: "pk_test_123")
+
+    XCTAssertEqual(dependencyContainer.storage.apiKey, "pk_test_123")
+  }
+
   func test_overwriteAssignments() {
     let dependencyContainer = DependencyContainer()
     let storage = Storage(factory: dependencyContainer)
@@ -36,4 +42,3 @@ class StorageTests: XCTestCase {
     XCTAssertTrue(retrievedAssignments2.isEmpty)
   }
 }
-


### PR DESCRIPTION
## Summary
- configure the dependency container's API key synchronously before any async startup work runs
- keep `/redeem` from racing ahead with `Authorization: Bearer ` when `ReceiptManager` registers the app transaction id early
- add a regression test covering the synchronous API-key setup invariant

## Why
`ReceiptManager` starts `setAppTransactionId()` during dependency construction. If that resolves quickly after `Superwall.isInitialized` becomes true, it can call `redeem(.existingCodes)` before the old async startup task had populated `storage.apiKey`, which means the shared header builder would emit an empty bearer token.

## Testing
- `swift test --filter StorageTests` *(fails in this environment because the active developer directory is Command Line Tools and the package imports UIKit: `no such module "UIKit"`)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a startup race condition where `ReceiptManager` could call `redeem(.existingCodes)` before `storage.apiKey` was populated, because the previous code set the key inside an async `Task` rather than synchronously during initialization.\n\n**Key changes:**\n- Introduces `Superwall.makeDependencyContainer(...)` — a static factory that constructs `DependencyContainer` and immediately calls `storage.configure(apiKey:)` synchronously before any async work begins.\n- The `private convenience init` now delegates container creation to this factory, removing the `storage.configure` call from inside the `Task`.\n- Adds a regression test asserting that storage is configured synchronously after `makeDependencyContainer` returns — though the test uses `XCTestCase` rather than the project-required Swift Testing framework (`CLAUDE.md`).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix is minimal, well-targeted, and correctly resolves the race condition with no risky side effects.

The core change is straightforward and correct: moving storage.configure(apiKey:) from inside an async Task to synchronous initialization eliminates the race. The only non-blocking issue is that the new regression test uses XCTest instead of the project-mandated Swift Testing framework.

Tests/SuperwallKitTests/Storage/StorageTests.swift — test should be rewritten using Swift Testing framework per CLAUDE.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Superwall.swift | Moves storage.configure(apiKey:) from inside the async Task into a new synchronous makeDependencyContainer factory, correctly eliminating the race where ReceiptManager could call redeem with an empty bearer token before the API key was set. |
| Tests/SuperwallKitTests/Storage/StorageTests.swift | Adds a regression test for the synchronous API-key setup invariant, but uses XCTest (XCTestCase / XCTAssertEqual) instead of the project-required Swift Testing framework. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (configure)
    participant S as Superwall.init
    participant MDC as makeDependencyContainer
    participant DC as DependencyContainer.init
    participant ST as Storage
    participant RM as ReceiptManager

    Note over S,RM: After fix — synchronous path
    C->>S: Superwall.configure(apiKey:)
    S->>MDC: makeDependencyContainer(apiKey:)
    MDC->>DC: DependencyContainer.init()
    DC->>ST: Storage.init()
    DC->>RM: ReceiptManager.init() [may start async work]
    DC-->>MDC: dependencyContainer
    MDC->>ST: storage.configure(apiKey:) synchronous before Task
    MDC-->>S: dependencyContainer (apiKey already set)
    S->>S: Task { recordAppInstall, fetchConfig }
    Note right of RM: If ReceiptManager calls redeem() here storage.apiKey is already populated
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Tests/SuperwallKitTests/Storage/StorageTests.swift
Line: 12-17

Comment:
**New test uses XCTest instead of Swift Testing**

`CLAUDE.md` explicitly requires: *"This project uses Swift's Testing framework (not XCTest) for all unit tests. Always use the Testing framework when writing new tests."*

The new test was added to the existing `XCTestCase` subclass rather than creating a new Swift Testing file. It should live in its own file using `import Testing` with `@Test` and `#expect`.

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=ae0afcf7-0b55-482b-9764-29f361e46714))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix redeem auth race during startup"](https://github.com/superwall/superwall-ios/commit/5cf675ca1ab89cce34fc528ebf6956a7a28c7adf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26466087)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=ae0afcf7-0b55-482b-9764-29f361e46714))

<!-- /greptile_comment -->