### PR TITLE
Expose abandoned transaction product params in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # CHANGELOG
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
-
+u
 ## 4.15.1
 
 ### Enhancements
 
 - Adds an `onCustomCallback` parameter to `getPaywall`.
 - `SuperwallOptions.localResources` now accepts UIImage's from xcasset files, e.g. `UIImage(named: "my-image")`.
+- Exposes abandoned transaction product params in audience filters.
 
 ## 4.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
-u
+
 ## 4.15.1
 
 ### Enhancements

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -672,8 +672,7 @@ enum InternalSuperwallEvent {
         if let product = product {
           params["abandoned_product_id"] = product.productIdentifier
           let hasRicherProductAttributes =
-            !product.localizedPrice.isEmpty
-            || !product.localizedSubscriptionPeriod.isEmpty
+            !product.localizedSubscriptionPeriod.isEmpty
             || !product.period.isEmpty
 
           if hasRicherProductAttributes {

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -671,6 +671,16 @@ enum InternalSuperwallEvent {
         var params = paywallInfo.audienceFilterParams()
         if let product = product {
           params["abandoned_product_id"] = product.productIdentifier
+          let hasRicherProductAttributes =
+            !product.localizedPrice.isEmpty
+            || !product.localizedSubscriptionPeriod.isEmpty
+            || !product.period.isEmpty
+
+          if hasRicherProductAttributes {
+            for (key, value) in product.attributes {
+              params["abandoned_product_\(key.camelCaseToSnakeCase())"] = value
+            }
+          }
         }
         return params
       default:

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -671,12 +671,8 @@ enum InternalSuperwallEvent {
         var params = paywallInfo.audienceFilterParams()
         if let product = product {
           params["abandoned_product_id"] = product.productIdentifier
-          let hasRicherProductAttributes =
-            !product.localizedSubscriptionPeriod.isEmpty
-            || !product.period.isEmpty
-
-          if hasRicherProductAttributes {
-            for (key, value) in product.attributes {
+          if !product.period.isEmpty {
+            for (key, value) in product.attributes where key != "identifier" {
               params["abandoned_product_\(key.camelCaseToSnakeCase())"] = value
             }
           }

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -1699,7 +1699,10 @@ struct TrackingTests {
     let paywallInfo: PaywallInfo = .stub()
     let productId = "abc"
     let product = StoreProduct(
-      sk1Product: MockSkProduct(productIdentifier: productId),
+      sk1Product: MockSkProduct(
+        subscriptionPeriod: SKProductSubscriptionPeriodMock(numberOfUnits: 1, unit: .month),
+        productIdentifier: productId
+      ),
       entitlements: [.stub()]
     )
     let dependencyContainer = DependencyContainer()
@@ -1726,10 +1729,10 @@ struct TrackingTests {
     #expect(
       result.parameters.audienceFilterParams["abandoned_product_id"] as! String == productId)
     #expect(result.parameters.audienceFilterParams["abandoned_product_identifier"] as! String == productId)
-    #expect(result.parameters.audienceFilterParams["abandoned_product_period"] != nil)
-    #expect(result.parameters.audienceFilterParams["abandoned_product_period_months"] != nil)
-    #expect(result.parameters.audienceFilterParams["abandoned_product_period_years"] != nil)
-    #expect(result.parameters.audienceFilterParams["abandoned_product_localized_period"] != nil)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period"] as? String == "month")
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period_months"] as? String == "1")
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period_years"] as? String == "0")
+    #expect((result.parameters.audienceFilterParams["abandoned_product_localized_period"] as? String)?.isEmpty == false)
   }
 
   @Test func transaction_fail() async {

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -1695,6 +1695,43 @@ struct TrackingTests {
       result.parameters.audienceFilterParams["presented_by_event_name"] as? String == paywallInfo.presentedByPlacementWithName)
   }
 
+  @Test func transaction_abandon() async {
+    let paywallInfo: PaywallInfo = .stub()
+    let productId = "abc"
+    let product = StoreProduct(
+      sk1Product: MockSkProduct(productIdentifier: productId),
+      entitlements: [.stub()]
+    )
+    let dependencyContainer = DependencyContainer()
+    let skTransaction = MockSKPaymentTransaction(state: .purchased)
+    let transaction = await dependencyContainer.makeStoreTransaction(from: skTransaction)
+    let result = await Superwall.shared.track(
+      InternalSuperwallEvent.Transaction(
+        state: .abandon(product),
+        paywallInfo: paywallInfo,
+        product: product,
+        transaction: transaction,
+        source: .external,
+        isObserved: false,
+        storeKitVersion: .storeKit1
+      )
+    )
+
+    #expect(result.parameters.audienceFilterParams["$event_name"] as! String == "transaction_abandon")
+    #expect(result.parameters.audienceFilterParams["$product_period"] != nil)
+    #expect(result.parameters.audienceFilterParams["$product_period_months"] != nil)
+
+    #expect(
+      result.parameters.audienceFilterParams["event_name"] as! String == "transaction_abandon")
+    #expect(
+      result.parameters.audienceFilterParams["abandoned_product_id"] as! String == productId)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_identifier"] as! String == productId)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period"] != nil)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period_months"] != nil)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_period_years"] != nil)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_localized_period"] != nil)
+  }
+
   @Test func transaction_fail() async {
     let paywallInfo: PaywallInfo = .stub()
     let productId = "abc"

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -1728,7 +1728,7 @@ struct TrackingTests {
       result.parameters.audienceFilterParams["event_name"] as! String == "transaction_abandon")
     #expect(
       result.parameters.audienceFilterParams["abandoned_product_id"] as! String == productId)
-    #expect(result.parameters.audienceFilterParams["abandoned_product_identifier"] as! String == productId)
+    #expect(result.parameters.audienceFilterParams["abandoned_product_identifier"] == nil)
     #expect(result.parameters.audienceFilterParams["abandoned_product_period"] as? String == "month")
     #expect(result.parameters.audienceFilterParams["abandoned_product_period_months"] as? String == "1")
     #expect(result.parameters.audienceFilterParams["abandoned_product_period_years"] as? String == "0")

--- a/Tests/SuperwallKitTests/StoreKit/Mocks/SKProductSubscriptionPeriodMock.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Mocks/SKProductSubscriptionPeriodMock.swift
@@ -9,7 +9,22 @@ import Foundation
 import StoreKit
 
 final class SKProductSubscriptionPeriodMock: SKProductSubscriptionPeriod {
+  private let internalNumberOfUnits: Int
+  private let internalUnit: SKProduct.PeriodUnit
+
   override var numberOfUnits: Int {
-    return 1
+    return internalNumberOfUnits
+  }
+
+  override var unit: SKProduct.PeriodUnit {
+    return internalUnit
+  }
+
+  init(
+    numberOfUnits: Int = 1,
+    unit: SKProduct.PeriodUnit = .month
+  ) {
+    self.internalNumberOfUnits = numberOfUnits
+    self.internalUnit = unit
   }
 }


### PR DESCRIPTION
## Problem
When configuring a paywall trigger for `transaction_abandon`, the dashboard filter UI only exposes `abandoned_product_id`.

The SDK already includes richer abandoned product metadata in the internal `$product_*` parameter set, but those fields are not copied into the explicit event parameter payload that powers the filter picker. As a result, you cannot target different paywalls based on the abandoned product duration.

## Intended use case
The goal is to show a different rescue paywall depending on which subscription duration was abandoned. For example:
- If the user abandons a yearly product, show a discounted yearly paywall
- If the user abandons a monthly product, show a discounted monthly paywall
- If the user abandons a weekly product, show a discounted weekly paywall

Right now that workflow is blocked because `transaction_abandon` does not expose duration-related fields in the filter UI.

## Solution
- Copy available abandoned product attributes into explicit `abandoned_product_*` event parameters
- Preserve the existing `abandoned_product_id` field
- Avoid emitting misleading empty duration fields for blank products used by Stripe/web checkout fallback paths
- Add test coverage for the new `transaction_abandon` parameter set

## Notes
This addresses the App Store abandon path where a real `StoreProduct` is available. Stripe/web checkout abandon still only has product ID in the current model, so duration-based filtering for that path would require additional Stripe product metadata to be tracked.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR copies `StoreProduct.attributes` into the `transaction_abandon` audience filter params under an `abandoned_product_*` prefix, guarded by `!product.period.isEmpty` so that Stripe/web products (which return an empty period) are unaffected. The `SKProductSubscriptionPeriodMock` is updated from a hardcoded `numberOfUnits: 1` to a configurable init to support the new test, following the same pattern already used by `MockSkProduct`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; the change is additive, well-guarded, and consistent with the existing product_* attribute pattern.

No P0 or P1 issues found. The !product.period.isEmpty guard correctly scopes the new params to App Store subscription products, the identifier key is explicitly excluded to avoid a duplicate with the separately set abandoned_product_id, and the implementation mirrors the pre-existing product_* pattern in PaywallInfo.audienceFilterParams(). Test coverage uses actual-value assertions for all new fields.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift | Adds abandoned_product_* params for subscription products in the transaction_abandon case, guarded by !product.period.isEmpty; excludes identifier key to avoid duplicate with abandoned_product_id. |
| Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift | Adds a new transaction_abandon test with actual-value assertions for the new abandoned_product_* fields and confirms abandoned_product_identifier is nil. |
| Tests/SuperwallKitTests/StoreKit/Mocks/SKProductSubscriptionPeriodMock.swift | Replaces hardcoded numberOfUnits: 1 with configurable init(numberOfUnits:unit:), matching the pattern used by MockSkProduct; existing callers retain the default behavior. |
| CHANGELOG.md | Adds changelog entry for the new exposed abandoned product params in audience filters. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Transaction.abandon state] --> B{product != nil?}
    B -- No --> E[return audienceFilterParams]
    B -- Yes --> C["set abandoned_product_id"]
    C --> D{"product.period.isEmpty?"}
    D -- "Yes - Stripe/web product" --> E
    D -- "No - App Store subscription" --> F["iterate product.attributes\nexcluding 'identifier' key"]
    F --> G["add abandoned_product_period\nabandoned_product_period_months\nabandoned_product_price, etc."]
    G --> E
```

<sub>Reviews (3): Last reviewed commit: ["Remove stray character in CHANGELOG"](https://github.com/superwall/superwall-ios/commit/4c77411fe6d0434b75657c34bc970640554e6cb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27805433)</sub>

<!-- /greptile_comment -->