### PR TITLE
Fix dismiss post purchase race

### DIFF
--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -1539,6 +1539,15 @@ extension PaywallViewController {
     closeReason: PaywallCloseReason,
     completion: (() -> Void)? = nil
   ) {
+    // Ignore redundant dismiss calls after a terminal purchase/restore.
+    switch paywallResult {
+    case .purchased, .restored:
+      completion?()
+      return
+    case .declined, .none:
+      break
+    }
+
     dismissCompletionBlock = completion
     paywallResult = result
     paywall.closeReason = closeReason

--- a/Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift
@@ -1,12 +1,11 @@
 //
-//  PaywallViewControllerDrawerTests.swift
+//  PaywallViewControllerTests.swift
 //  SuperwallKitTests
-//
-//  Created by Claude on 08/01/2025.
 //
 
 import Testing
 import Foundation
+import StoreKit
 @testable import SuperwallKit
 
 struct PaywallViewControllerDrawerTests {
@@ -126,5 +125,89 @@ struct PaywallViewControllerDrawerTests {
     #expect(PaywallPresentationStyleObjc.fullscreen.toSwift() == .fullscreen)
     #expect(PaywallPresentationStyleObjc.push.toSwift() == .push)
     #expect(PaywallPresentationStyleObjc.none.toSwift() == .none)
+  }
+}
+
+@MainActor
+struct PaywallViewControllerDismissIdempotencyTests {
+  final class RecordingDelegate: PaywallViewControllerDelegate {
+    nonisolated(unsafe) var results: [PaywallResult] = []
+    func paywall(
+      _ paywall: PaywallViewController,
+      didFinishWith result: PaywallResult,
+      shouldDismiss: Bool
+    ) {
+      results.append(result)
+    }
+  }
+
+  private func makeMock() -> PaywallViewControllerMock {
+    let dependencyContainer = DependencyContainer()
+    let messageHandler = PaywallMessageHandler(
+      receiptManager: dependencyContainer.receiptManager,
+      factory: dependencyContainer,
+      permissionHandler: FakePermissionHandler(),
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
+    )
+    let webView = SWWebView(
+      isMac: false,
+      messageHandler: messageHandler,
+      isOnDeviceCacheEnabled: true,
+      factory: dependencyContainer
+    )
+    return PaywallViewControllerMock(
+      paywall: .stub(),
+      deviceHelper: dependencyContainer.deviceHelper,
+      factory: dependencyContainer,
+      storage: dependencyContainer.storage,
+      network: dependencyContainer.network,
+      webView: webView,
+      webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
+      cache: nil,
+      paywallArchiveManager: nil
+    )
+  }
+
+  @Test("`.closed` dismiss after a successful purchase is ignored")
+  func closedEventAfterPurchaseIsIgnored() async throws {
+    let paywallVc = makeMock()
+    let recorder = RecordingDelegate()
+    paywallVc.delegate = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: recorder,
+      objcDelegate: nil
+    )
+
+    let product = StoreProduct(
+      sk1Product: MockSkProduct(productIdentifier: "com.example.test")
+    )
+
+    paywallVc.dismiss(result: .purchased(product), closeReason: .systemLogic)
+    paywallVc.dismiss(result: .declined, closeReason: .manualClose)
+
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(recorder.results.count == 1)
+    if case .purchased = recorder.results.first {
+    } else {
+      Issue.record("Expected delegate to receive .purchased only, got \(recorder.results)")
+    }
+  }
+
+  @Test("`.closed` dismiss after a restore is ignored")
+  func closedEventAfterRestoreIsIgnored() async throws {
+    let paywallVc = makeMock()
+    let recorder = RecordingDelegate()
+    paywallVc.delegate = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: recorder,
+      objcDelegate: nil
+    )
+
+    paywallVc.dismiss(result: .restored, closeReason: .systemLogic)
+    paywallVc.dismiss(result: .declined, closeReason: .manualClose)
+
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(recorder.results.count == 1)
+    #expect(recorder.results.first == .restored)
   }
 }


### PR DESCRIPTION
## Changes in this pull request

- 

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an idempotency guard to `PaywallViewController.dismiss(result:closeReason:completion:)` that short-circuits any subsequent dismiss call when `paywallResult` is already `.purchased` or `.restored`, preventing a system-close event from overwriting a terminal purchase/restore state. Two new `@MainActor` tests cover both the purchase and restore scenarios; the test file is also renamed from `PaywallViewControllerDrawerTests` to `PaywallViewControllerTests`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard is logically correct and all remaining findings are P2 style suggestions.

The fix synchronously guards on the already-set `paywallResult` property before any async work begins. Since `PaywallViewController` is `@MainActor`, reads and writes of `paywallResult` are serialized, making the guard race-free by construction. All open findings are P2.

Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift — minor test quality concerns (sleep-based assertions, nonisolated(unsafe)).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift | Adds an early-return idempotency guard at the top of `dismiss(result:closeReason:completion:)` that ignores any dismiss call when `paywallResult` is already `.purchased` or `.restored`, fixing the post-purchase race condition. |
| Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift | Renames the existing drawer test file and adds two new `@MainActor` tests verifying idempotency; minor concerns around time-based async assertions and `nonisolated(unsafe)` usage. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TM as TransactionManager
    participant PVC as PaywallViewController
    participant Sys as System (viewDidDisappear)
    participant Del as Delegate

    TM->>PVC: dismiss(result: .purchased, closeReason: .systemLogic)
    Note over PVC: paywallResult = nil → guard passes<br/>paywallResult set to .purchased
    PVC->>Del: didFinish(result: .purchased, shouldDismiss: true)
    Note over PVC: UIKit dismiss animation starts

    Sys->>PVC: dismiss(result: .declined, closeReason: .manualClose)
    Note over PVC: paywallResult == .purchased → guard triggers<br/>completion?() called, return early
    PVC-->>Sys: (completion called, no delegate call)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift
Line: 177-180

Comment:
**Time-based async assertion is fragile**

The 100 ms sleep is used to wait for the async `dismissView()` delegate call to complete. In slow CI environments or under heavy load this window can be missed, causing the assertion to see 0 results and fail spuriously. Consider structuring the test so the delegate call is awaited directly via a `withCheckedContinuation` or an `AsyncStream`-based expectation instead of a fixed sleep.

The same concern applies to the restore test at line 207.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Tests/SuperwallKitTests/Paywall/View Controller/PaywallViewControllerTests.swift
Line: 134-136

Comment:
**`nonisolated(unsafe)` bypasses Swift concurrency checks**

`nonisolated(unsafe) var results` disables actor-isolation enforcement on `RecordingDelegate`. If the delegate is ever called off the main actor the mutation would be a data race. Since the enclosing test suite is `@MainActor` and `PaywallViewController` also runs on the main actor the access is safe in practice, but marking `RecordingDelegate` itself `@MainActor` would be cleaner and restore compiler-enforced isolation.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix dismiss post purchase race"](https://github.com/superwall/superwall-ios/commit/0322e751e4e279667adf3000f4844290370ba9f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28495785)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->