### PR TITLE
Sanitize email user attribute before sending to checkout API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - `SuperwallOptions.localResources` now accepts UIImage's from xcasset files, e.g. `UIImage(named: "my-image")`.
 - Exposes abandoned transaction product params in audience filters.
 
+### Fixes
+
+- Sanitizes email user attribute.
+
 ## 4.15.0
 
 ### Enhancements

--- a/Sources/SuperwallKit/Identity/Email.swift
+++ b/Sources/SuperwallKit/Identity/Email.swift
@@ -8,14 +8,17 @@ import Foundation
 /// A validated email address.
 ///
 /// The failable initializer rejects any string that does not match the
-/// pattern expected by the checkout API (`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`).
+/// pattern expected by the checkout API (`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z`).
 /// Holding an `Email` instance proves the value was validated — downstream
 /// code never needs to re-check.
 struct Email: Equatable, Sendable {
   let rawValue: String
 
-  private static let regex = try! NSRegularExpression(
-    pattern: #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"#
+  // `\z` (not `$`) is used so that a trailing `\n` is rejected — ICU treats `$`
+  // as matching at end-of-string *or* just before a final newline.
+  // Pattern is a validated literal — initialization can never throw at runtime.
+  private static let regex = try! NSRegularExpression( // swiftlint:disable:this force_try
+    pattern: #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\z"#
   )
 
   /// Returns `nil` when `rawValue` is not a syntactically valid email address.

--- a/Sources/SuperwallKit/Identity/Email.swift
+++ b/Sources/SuperwallKit/Identity/Email.swift
@@ -1,0 +1,29 @@
+//
+//  Email.swift
+//  SuperwallKit
+//
+
+import Foundation
+
+/// A validated email address.
+///
+/// The failable initializer rejects any string that does not match the
+/// pattern expected by the checkout API (`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`).
+/// Holding an `Email` instance proves the value was validated — downstream
+/// code never needs to re-check.
+struct Email: Equatable, Sendable {
+  let rawValue: String
+
+  private static let regex = try! NSRegularExpression(
+    pattern: #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"#
+  )
+
+  /// Returns `nil` when `rawValue` is not a syntactically valid email address.
+  init?(_ rawValue: String) {
+    let range = NSRange(rawValue.startIndex..., in: rawValue)
+    guard Self.regex.firstMatch(in: rawValue, range: range) != nil else {
+      return nil
+    }
+    self.rawValue = rawValue
+  }
+}

--- a/Sources/SuperwallKit/Identity/UserAttributes.swift
+++ b/Sources/SuperwallKit/Identity/UserAttributes.swift
@@ -94,11 +94,39 @@ extension Superwall {
           continue
         }
         if JSONSerialization.isValidJSONObject([key: value]) {
-          customAttributes[key] = value
+          customAttributes[key] = Self.sanitizeAttribute(key: key, value: value)
         }
       }
     }
 
     dependencyContainer.identityManager.mergeUserAttributes(customAttributes)
+  }
+
+  /// Validates attribute values that have server-side schema constraints.
+  ///
+  /// The checkout API rejects `context.identity.email` unless it is either a
+  /// valid email address or `null`. Apps that set a placeholder like `"none"`
+  /// would silently break the Stripe checkout flow, so the SDK parses the
+  /// value through ``Email`` and drops it when invalid.
+  static func sanitizeAttribute(key: String, value: Any?) -> Any? {
+    guard let stringValue = value as? String else {
+      return value
+    }
+
+    switch key {
+    case "email":
+      guard let email = Email(stringValue) else {
+        Logger.debug(
+          logLevel: .warn,
+          scope: .identityManager,
+          message: "Invalid email user attribute \"\(stringValue)\" — sending null to server"
+        )
+        return nil
+      }
+      return email.rawValue
+
+    default:
+      return value
+    }
   }
 }

--- a/Tests/SuperwallKitTests/Identity/EmailTests.swift
+++ b/Tests/SuperwallKitTests/Identity/EmailTests.swift
@@ -69,6 +69,7 @@ struct EmailTests {
       "not an email",
       "null",
       "N/A",
+      "user@example.com\n",
     ]
   )
   func `rejects invalid value`(value: String) {

--- a/Tests/SuperwallKitTests/Identity/EmailTests.swift
+++ b/Tests/SuperwallKitTests/Identity/EmailTests.swift
@@ -1,0 +1,131 @@
+//
+//  EmailTests.swift
+//  SuperwallKit
+//
+
+import Testing
+@testable import SuperwallKit
+
+@Suite("Email")
+struct EmailTests {
+
+  // MARK: - Valid emails
+
+  @Test("accepts a simple email address")
+  func `simple email`() {
+    #expect(Email("user@example.com") != nil)
+  }
+
+  @Test("accepts email with dots in local part")
+  func `dotted local part`() {
+    #expect(Email("first.last@domain.co") != nil)
+  }
+
+  @Test("accepts email with plus tag")
+  func `plus tag`() {
+    #expect(Email("user+tag@example.com") != nil)
+  }
+
+  @Test("accepts email with subdomain")
+  func `subdomain`() {
+    #expect(Email("user@mail.example.co.uk") != nil)
+  }
+
+  @Test("accepts email with numbers")
+  func `numbers`() {
+    #expect(Email("user123@domain456.com") != nil)
+  }
+
+  @Test("accepts email with hyphen in domain")
+  func `hyphenated domain`() {
+    #expect(Email("user@my-domain.com") != nil)
+  }
+
+  @Test("accepts email with underscore and percent")
+  func `underscore and percent`() {
+    #expect(Email("user_%name@domain.org") != nil)
+  }
+
+  @Test("preserves the raw value on success")
+  func `preserves raw value`() {
+    let address = "hello@world.com"
+    let email = Email(address)
+    #expect(email?.rawValue == address)
+  }
+
+  // MARK: - Invalid emails
+
+  @Test(
+    "rejects strings that are not valid email addresses",
+    arguments: [
+      "none",
+      "",
+      "userexample.com",
+      "user@",
+      "@example.com",
+      "user@domain",
+      "user@domain.a",
+      "user @example.com",
+      "not an email",
+      "null",
+      "N/A",
+    ]
+  )
+  func `rejects invalid value`(value: String) {
+    #expect(Email(value) == nil)
+  }
+
+  // MARK: - Equatable
+
+  @Test("two emails with the same address are equal")
+  func `equal emails`() {
+    #expect(Email("a@b.com") == Email("a@b.com"))
+  }
+
+  @Test("two emails with different addresses are not equal")
+  func `different emails`() {
+    #expect(Email("a@b.com") != Email("x@y.com"))
+  }
+}
+
+// MARK: - sanitizeAttribute
+
+@Suite("Superwall.sanitizeAttribute")
+struct SanitizeAttributeTests {
+
+  @Test("passes a valid email through unchanged")
+  func `valid email passes through`() {
+    let result = Superwall.sanitizeAttribute(key: "email", value: "user@example.com")
+    #expect(result as? String == "user@example.com")
+  }
+
+  @Test("replaces the placeholder 'none' with nil for the email key")
+  func `none placeholder becomes nil`() {
+    let result = Superwall.sanitizeAttribute(key: "email", value: "none")
+    #expect(result == nil)
+  }
+
+  @Test("replaces an empty string with nil for the email key")
+  func `empty string becomes nil`() {
+    let result = Superwall.sanitizeAttribute(key: "email", value: "")
+    #expect(result == nil)
+  }
+
+  @Test("does not sanitize non-email keys")
+  func `non email key untouched`() {
+    let result = Superwall.sanitizeAttribute(key: "name", value: "none")
+    #expect(result as? String == "none")
+  }
+
+  @Test("does not sanitize non-string values on the email key")
+  func `non string value untouched`() {
+    let result = Superwall.sanitizeAttribute(key: "email", value: 42)
+    #expect(result as? Int == 42)
+  }
+
+  @Test("passes nil through unchanged")
+  func `nil value passes through`() {
+    let result = Superwall.sanitizeAttribute(key: "email", value: nil)
+    #expect(result == nil)
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce an `Email` type with a failable initializer that validates against the regex enforced by the checkout API (`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
- Sanitize the `email` user attribute in `mergeAttributes` — invalid values are replaced with `nil` so the server receives `null` instead of a malformed string
- Log a warning when an invalid email is dropped so app developers get feedback

## Context

When an app sets the `email` user attribute to a placeholder like `"none"` (e.g. when the user hasn't provided an email yet), the checkout API rejects the request with an `HttpApiDecodeError` because `"none"` is neither a valid email nor `null`. This silently breaks the Stripe checkout — the payment sheet never opens and the user sees no feedback.

The fix parses the email value at the SDK boundary so the server always receives either a valid email or `null`, regardless of what the app sends.

## Test plan

- [x] Unit tests on `Email` type (valid addresses, parameterized invalid inputs including `"none"`, `""`, `"null"`, `"N/A"`)
- [x] Unit tests on `sanitizeAttribute` (valid passthrough, invalid → nil, non-email keys untouched, non-string values untouched)
- [ ] Manual: set `email` attribute to `"none"` → verify Stripe checkout opens (previously broken)
- [ ] Manual: set `email` attribute to a real email → verify it's forwarded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an `Email` value type that validates against the checkout API's regex, and applies it in `mergeAttributes` so that invalid email strings (e.g. `"none"`) are silently dropped instead of forwarded to the server. The change is focused and well-tested with a parameterized test suite covering both the type and the sanitizer.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is well-scoped, correctly integrated, and fully covered by unit tests.

No P0 or P1 issues found. The Email type is correctly anchored with `\z`, the sanitizer integrates cleanly with existing nil-drop semantics in `mergeAttributes`, and the test suite covers the key invalid placeholders and edge cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Identity/Email.swift | New value type with regex-backed failable initializer; correctly uses `\z` anchor and force-try with lint suppression comment. |
| Sources/SuperwallKit/Identity/UserAttributes.swift | Adds `sanitizeAttribute` static helper that validates email values; integrates cleanly into existing `mergeAttributes` flow with correct nil-drop semantics. |
| Tests/SuperwallKitTests/Identity/EmailTests.swift | Comprehensive parameterized tests covering valid addresses, known invalid placeholders (none, null, N/A, trailing newline), and the sanitizer helper. |
| CHANGELOG.md | Adds fix entry under the upcoming release section. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["setUserAttributes(['email': value])"] --> B[mergeAttributes]
    B --> C{value is nil?}
    C -- yes --> D[skip key]
    C -- no --> E{isValidJSONObject?}
    E -- no --> D
    E -- yes --> F["sanitizeAttribute(key:value:)"]
    F --> G{key == 'email'?}
    G -- no --> H[return value unchanged]
    G -- yes --> I{value is String?}
    I -- no --> H
    I -- yes --> J{Email init succeeds?}
    J -- yes --> K[return email.rawValue]
    J -- no --> L[log warning\nreturn nil]
    L --> M[key removed from customAttributes]
    K --> N[customAttributes updated]
    H --> N
    N --> O[identityManager.mergeUserAttributes]
    M --> O
    O --> P[IdentityLogic.mergeAttributes\nmerges with stored attrs]
    P --> Q[Server receives valid email or null]
```

<sub>Reviews (3): Last reviewed commit: ["Add CHANGELOG entry for email user attri..."](https://github.com/superwall/superwall-ios/commit/c6c57881b56ee5c6dbf3d483924a7acf2e61550a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28618377)</sub>

<!-- /greptile_comment -->