### PR TITLE
Wire custom callbacks through getPaywall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.15.1
+
+### Enhancements
+
+- Adds an `onCustomCallback` parameter to `getPaywall(forPlacement:params:paywallOverrides:delegate:onCustomCallback:)` so paywalls retrieved for embedding can handle custom webview callbacks. Previously, custom callbacks were only supported via `register()`, which presents in its own `UIWindow`.
+
 ## 4.15.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Enhancements
 
-- Adds an `onCustomCallback` parameter to `getPaywall(forPlacement:params:paywallOverrides:delegate:onCustomCallback:)` so paywalls retrieved for embedding can handle custom webview callbacks. Previously, custom callbacks were only supported via `register()`, which presents in its own `UIWindow`.
+- Adds an `onCustomCallback` parameter to `getPaywall`.
 
 ## 4.15.0
 

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -314,7 +314,8 @@ extension DependencyContainer: ViewControllerFactory {
       webView: webView,
       webEntitlementRedeemer: webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: paywallArchiveManager
+      paywallArchiveManager: paywallArchiveManager,
+      customCallbackRegistry: customCallbackRegistry
     )
 
     webView.delegate = paywallViewController

--- a/Sources/SuperwallKit/Graveyard/SuperwallGraveyard.swift
+++ b/Sources/SuperwallKit/Graveyard/SuperwallGraveyard.swift
@@ -107,7 +107,8 @@ extension Superwall {
       ),
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: dependencyContainer.makeCache(),
-      paywallArchiveManager: dependencyContainer.paywallArchiveManager
+      paywallArchiveManager: dependencyContainer.paywallArchiveManager,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
   }
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.15.0
+4.15.1
 """

--- a/Sources/SuperwallKit/Paywall/Presentation/Get Paywall/PublicGetPaywall.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get Paywall/PublicGetPaywall.swift
@@ -24,6 +24,9 @@ extension Superwall {
   ///   be dropped.
   ///   - paywallOverrides: An optional ``PaywallOverrides`` object whose parameters override the paywall defaults. Use this to override products and presentation style. Defaults to `nil`.
   ///   - delegate: A delegate responsible for handling user interactions with the retrieved ``PaywallViewController``.
+  ///   - onCustomCallback: An optional async block invoked when the paywall webview triggers a custom callback.
+  ///   Return a ``CustomCallbackResult`` to report success or failure back to the webview. Defaults to `nil`, in which
+  ///   case the webview receives a failure result for any custom callbacks.
   ///   - completion: A completion block accepting an optional ``PaywallViewController``, an optional
   ///   ``PaywallSkippedReason`` and an optional `Error`. If the ``PaywallViewController`` couldn't be retrieved
   ///   because its presentation should be skipped, the ``PaywallSkippedReason`` will be non-`nil`. Any errors
@@ -35,6 +38,7 @@ extension Superwall {
     params: [String: Any]? = nil,
     paywallOverrides: PaywallOverrides? = nil,
     delegate: PaywallViewControllerDelegate,
+    onCustomCallback: ((CustomCallback) async -> CustomCallbackResult)? = nil,
     completion: @escaping (PaywallViewController?, PaywallSkippedReason?, Error?) -> Void
   ) {
     Task { @MainActor in
@@ -43,7 +47,8 @@ extension Superwall {
           forPlacement: placement,
           params: params,
           paywallOverrides: paywallOverrides,
-          delegate: delegate
+          delegate: delegate,
+          onCustomCallback: onCustomCallback
         )
         completion(paywallViewController, nil, nil)
       } catch let reason as PaywallSkippedReason {
@@ -68,6 +73,9 @@ extension Superwall {
   ///   be dropped.
   ///   - paywallOverrides: An optional ``PaywallOverrides`` object whose parameters override the paywall defaults. Use this to override products and presentation style. Defaults to `nil`.
   ///   - delegate: A delegate responsible for handling user interactions with the retrieved ``PaywallViewController``.
+  ///   - onCustomCallback: An optional async block invoked when the paywall webview triggers a custom callback.
+  ///   Return a ``CustomCallbackResult`` to report success or failure back to the webview. Defaults to `nil`, in which
+  ///   case the webview receives a failure result for any custom callbacks.
   ///
   /// - Returns: A ``PaywallViewController`` object.
   /// - Throws: An `Error` explaining why it couldn't get the view controller. If the ``PaywallViewController`` couldn't be retrieved
@@ -80,7 +88,8 @@ extension Superwall {
     forPlacement placement: String,
     params: [String: Any]? = nil,
     paywallOverrides: PaywallOverrides? = nil,
-    delegate: PaywallViewControllerDelegate
+    delegate: PaywallViewControllerDelegate,
+    onCustomCallback: ((CustomCallback) async -> CustomCallbackResult)? = nil
   ) async throws -> PaywallViewController {
     return try await internallyGetPaywall(
       forPlacement: placement,
@@ -88,7 +97,8 @@ extension Superwall {
       paywallOverrides: paywallOverrides,
       delegate: .init(
         swiftDelegate: delegate,
-        objcDelegate: nil
+        objcDelegate: nil,
+        onCustomCallback: onCustomCallback
       )
     )
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
@@ -12,16 +12,21 @@ final class PaywallViewControllerDelegateAdapter {
   weak var swiftDelegate: PaywallViewControllerDelegate?
   weak var objcDelegate: PaywallViewControllerDelegateObjc?
 
+  /// An optional handler invoked when the paywall webview triggers a custom callback.
+  let onCustomCallback: ((CustomCallback) async -> CustomCallbackResult)?
+
   var hasObjcDelegate: Bool {
     return objcDelegate != nil
   }
 
   init(
     swiftDelegate: PaywallViewControllerDelegate?,
-    objcDelegate: PaywallViewControllerDelegateObjc?
+    objcDelegate: PaywallViewControllerDelegateObjc?,
+    onCustomCallback: ((CustomCallback) async -> CustomCallbackResult)? = nil
   ) {
     self.swiftDelegate = swiftDelegate
     self.objcDelegate = objcDelegate
+    self.onCustomCallback = onCustomCallback
   }
 
   @MainActor

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -71,7 +71,11 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     }
   }
 
-  var delegate: PaywallViewControllerDelegateAdapter?
+  var delegate: PaywallViewControllerDelegateAdapter? {
+    didSet {
+      syncCustomCallbackRegistration()
+    }
+  }
 
   typealias Factory = TriggerFactory
     & RestoreAccessFactory
@@ -215,6 +219,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   private unowned let storage: Storage
   private unowned let deviceHelper: DeviceHelper
   private unowned let webEntitlementRedeemer: WebEntitlementRedeemer
+  private unowned let customCallbackRegistry: CustomCallbackRegistry
   private weak var cache: PaywallViewControllerCache?
   private weak var paywallArchiveManager: PaywallArchiveManager?
 
@@ -231,7 +236,8 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     webView: SWWebView,
     webEntitlementRedeemer: WebEntitlementRedeemer,
     cache: PaywallViewControllerCache?,
-    paywallArchiveManager: PaywallArchiveManager?
+    paywallArchiveManager: PaywallArchiveManager?,
+    customCallbackRegistry: CustomCallbackRegistry
   ) {
     self.cache = cache
     self.paywallArchiveManager = paywallArchiveManager
@@ -248,13 +254,32 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     self.webView = webView
     self.introOfferTokenManager = IntroOfferTokenManager(network: network)
     self.webEntitlementRedeemer = webEntitlementRedeemer
+    self.customCallbackRegistry = customCallbackRegistry
 
     presentationStyle = paywall.presentation.style
     super.init(nibName: nil, bundle: nil)
+    syncCustomCallbackRegistration()
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  /// Registers or unregisters the delegate's custom callback handler with
+  /// ``CustomCallbackRegistry`` so the paywall webview can invoke it.
+  ///
+  /// `register()` manages registration around its own present/dismiss lifecycle, so this
+  /// path is the one that wires up handlers supplied via
+  /// ``Superwall/getPaywall(forPlacement:params:paywallOverrides:delegate:onCustomCallback:)``.
+  private func syncCustomCallbackRegistration() {
+    if let handler = delegate?.onCustomCallback {
+      customCallbackRegistry.register(
+        paywallIdentifier: paywall.identifier,
+        handler: handler
+      )
+    } else {
+      customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
+    }
   }
 
   public override func viewDidLoad() {
@@ -266,6 +291,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
 
   deinit {
     introOfferTokenManager.stopObservingAppLifecycle()
+    customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
   }
 
   private func configureUI() {

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -271,14 +271,18 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   /// `register()` manages registration around its own present/dismiss lifecycle, so this
   /// path is the one that wires up handlers supplied via
   /// ``Superwall/getPaywall(forPlacement:params:paywallOverrides:delegate:onCustomCallback:)``.
+  private var hasRegisteredCallback = false
+
   private func syncCustomCallbackRegistration() {
     if let handler = delegate?.onCustomCallback {
       customCallbackRegistry.register(
         paywallIdentifier: paywall.identifier,
         handler: handler
       )
-    } else {
+      hasRegisteredCallback = true
+    } else if hasRegisteredCallback {
       customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
+      hasRegisteredCallback = false
     }
   }
 
@@ -291,7 +295,9 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
 
   deinit {
     introOfferTokenManager.stopObservingAppLifecycle()
-    customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
+    if hasRegisteredCallback {
+      customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
+    }
   }
 
   private func configureUI() {

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.15.0"
+  s.version      = "4.15.1"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		B15607185B9E4229C6C4F240 /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B96E2A1A289D96267EC0BC /* SK2StoreTransaction.swift */; };
 		B294572426111EC04F225289 /* MockExternalPurchaseControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9C9132109020FA03D1D5C7 /* MockExternalPurchaseControllerFactory.swift */; };
 		B2AB1E9283FDE2D544C8BCA8 /* MockReceiptData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B81D88316F06C0C2757F10 /* MockReceiptData.swift */; };
+		B2AC4436371BC96FAA4FB5B3 /* CustomCallbackRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFC75AD1252D05D2033D7B0 /* CustomCallbackRegistryTests.swift */; };
 		B2B5684F46FB49AB9E3C1BE0 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E47DA89C9F4FBD7FA038F5 /* Cache.swift */; };
 		B3E6E82C0240EE6048360C9B /* RawWebMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C39015ED9E8F5D9F0F78F1E /* RawWebMessageHandler.swift */; };
 		B456ED8E41AD35A0EF5C295F /* ProductVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8730F0D05BFDFA12AA6309 /* ProductVariable.swift */; };
@@ -874,6 +875,7 @@
 		8BAEECE2DBFEB8817E6C36DA /* PaywallViewControllerCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerCache.swift; sourceTree = "<group>"; };
 		8BDA9D233EACAB5090B0657D /* StorePresentationObjectsOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePresentationObjectsOperatorTests.swift; sourceTree = "<group>"; };
 		8CA2E0A3532CE2F0AFD6F20B /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		8CFC75AD1252D05D2033D7B0 /* CustomCallbackRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCallbackRegistryTests.swift; sourceTree = "<group>"; };
 		8D45DC0981EE9BBE3BF56C48 /* PurchaseController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseController.swift; sourceTree = "<group>"; };
 		8D5F8BE7E93645C0FCA49E4A /* PopupTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTransition.swift; sourceTree = "<group>"; };
 		8D9545633A97A2E63FEDF78A /* SWWebViewLoadingHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWWebViewLoadingHandler.swift; sourceTree = "<group>"; };
@@ -2076,6 +2078,7 @@
 		75743C9AAFCAB9D91984F19C /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				8CFC75AD1252D05D2033D7B0 /* CustomCallbackRegistryTests.swift */,
 				A3F306D67A9F3A43D082DD83 /* PresentationIdTests.swift */,
 				43F99E26CAFD72F228189A4D /* Audience Logic */,
 				B2C3E282003472D3326477C4 /* Internal Presentation */,
@@ -3189,6 +3192,7 @@
 				A1621A749D8F05959A486ACE /* CoreDataManagerMock.swift in Sources */,
 				C7AB21123540550E513AD28A /* CoreDataManagerTests.swift in Sources */,
 				ABC17AE96AD396607E3CAB17 /* CoreDataStackMock.swift in Sources */,
+				B2AC4436371BC96FAA4FB5B3 /* CustomCallbackRegistryTests.swift in Sources */,
 				2517FC60F3A7288C5FE34A73 /* CustomProductTests.swift in Sources */,
 				85728EABBC5C73193AC5F876 /* CustomURLSessionMock.swift in Sources */,
 				37FDB46DD55E649FA10D753C /* CustomerInfoDecodingTests.swift in Sources */,

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackingLogicTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackingLogicTests.swift
@@ -320,7 +320,8 @@ struct TrackingLogicTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     let outcome = await TrackingLogic.canTriggerPaywall(

--- a/Tests/SuperwallKitTests/Paywall/Presentation/CustomCallbackRegistryTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/CustomCallbackRegistryTests.swift
@@ -1,0 +1,167 @@
+//
+//  CustomCallbackRegistryTests.swift
+//
+//
+//  Created by Yusuf Tör on 22/04/2026.
+//
+
+import Testing
+import Foundation
+@testable import SuperwallKit
+
+@Suite
+@MainActor
+struct CustomCallbackGetPaywallTests {
+  private func makePaywallVc(
+    paywall: Paywall,
+    delegate: PaywallViewControllerDelegateAdapter?,
+    in dependencyContainer: DependencyContainer
+  ) -> PaywallViewControllerMock {
+    let messageHandler = PaywallMessageHandler(
+      receiptManager: dependencyContainer.receiptManager,
+      factory: dependencyContainer,
+      permissionHandler: FakePermissionHandler(),
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
+    )
+    let webView = SWWebView(
+      isMac: false,
+      messageHandler: messageHandler,
+      isOnDeviceCacheEnabled: true,
+      factory: dependencyContainer
+    )
+    return PaywallViewControllerMock(
+      paywall: paywall,
+      delegate: delegate,
+      deviceHelper: dependencyContainer.deviceHelper,
+      factory: dependencyContainer,
+      storage: dependencyContainer.storage,
+      network: dependencyContainer.network,
+      webView: webView,
+      webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
+      cache: nil,
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
+    )
+  }
+
+  @Test
+  func customCallbackHandlerIsRegisteredWhenAdapterHasHandler() async {
+    let dependencyContainer = DependencyContainer()
+    let paywall = Paywall.stub()
+      .setting(\.identifier, to: "paywall_register_test")
+
+    let adapter = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: nil,
+      objcDelegate: nil,
+      onCustomCallback: { callback in
+        return .success(data: ["echo": callback.name])
+      }
+    )
+
+    let paywallVc = makePaywallVc(paywall: paywall, delegate: adapter, in: dependencyContainer)
+
+    let registered = dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )
+    #expect(registered != nil)
+
+    let result = await registered?(CustomCallback(name: "ping", variables: nil))
+    #expect(result?.status == .success)
+    #expect(result?.data?["echo"] as? String == "ping")
+
+    _ = paywallVc
+  }
+
+  @Test
+  func noHandlerRegisteredWhenAdapterHasNone() async {
+    let dependencyContainer = DependencyContainer()
+    let paywall = Paywall.stub()
+      .setting(\.identifier, to: "paywall_no_handler_test")
+
+    let adapter = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: nil,
+      objcDelegate: nil,
+      onCustomCallback: nil
+    )
+
+    let paywallVc = makePaywallVc(paywall: paywall, delegate: adapter, in: dependencyContainer)
+
+    let registered = dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )
+    #expect(registered == nil)
+
+    _ = paywallVc
+  }
+
+  @Test
+  func reassigningDelegateUpdatesRegistration() async {
+    let dependencyContainer = DependencyContainer()
+    let paywall = Paywall.stub()
+      .setting(\.identifier, to: "paywall_reassign_test")
+
+    let firstAdapter = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: nil,
+      objcDelegate: nil,
+      onCustomCallback: { _ in .success(data: ["origin": "first"]) }
+    )
+
+    let paywallVc = makePaywallVc(
+      paywall: paywall,
+      delegate: firstAdapter,
+      in: dependencyContainer
+    )
+
+    let firstResult = await dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )?(CustomCallback(name: "anything", variables: nil))
+    #expect(firstResult?.data?["origin"] as? String == "first")
+
+    let secondAdapter = PaywallViewControllerDelegateAdapter(
+      swiftDelegate: nil,
+      objcDelegate: nil,
+      onCustomCallback: { _ in .success(data: ["origin": "second"]) }
+    )
+    paywallVc.delegate = secondAdapter
+
+    let secondResult = await dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )?(CustomCallback(name: "anything", variables: nil))
+    #expect(secondResult?.data?["origin"] as? String == "second")
+
+    paywallVc.delegate = nil
+
+    let cleared = dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )
+    #expect(cleared == nil)
+  }
+
+  @Test
+  func handlerIsUnregisteredWhenViewControllerDeinits() async {
+    let dependencyContainer = DependencyContainer()
+    let paywall = Paywall.stub()
+      .setting(\.identifier, to: "paywall_deinit_test")
+
+    weak var weakVc: PaywallViewControllerMock?
+    autoreleasepool {
+      let adapter = PaywallViewControllerDelegateAdapter(
+        swiftDelegate: nil,
+        objcDelegate: nil,
+        onCustomCallback: { _ in .success(data: nil) }
+      )
+      let pvc = makePaywallVc(paywall: paywall, delegate: adapter, in: dependencyContainer)
+      weakVc = pvc
+      #expect(dependencyContainer.customCallbackRegistry.getHandler(
+        paywallIdentifier: paywall.identifier
+      ) != nil)
+      _ = pvc
+    }
+
+    #expect(weakVc == nil)
+    let registered = dependencyContainer.customCallbackRegistry.getHandler(
+      paywallIdentifier: paywall.identifier
+    )
+    #expect(registered == nil)
+  }
+}

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/PresentPaywallOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/PresentPaywallOperatorTests.swift
@@ -55,7 +55,8 @@ final class PresentPaywallOperatorTests {
         webView: webView,
         webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
         cache: nil,
-        paywallArchiveManager: nil
+        paywallArchiveManager: nil,
+        customCallbackRegistry: dependencyContainer.customCallbackRegistry
       )
 
       webView.delegate = paywallVc
@@ -124,7 +125,8 @@ final class PresentPaywallOperatorTests {
         webView: webView,
         webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
         cache: nil,
-        paywallArchiveManager: nil
+        paywallArchiveManager: nil,
+        customCallbackRegistry: dependencyContainer.customCallbackRegistry
       )
       paywallVc.shouldPresent = false
       webView.delegate = paywallVc

--- a/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
@@ -40,7 +40,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -87,7 +88,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -134,7 +136,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation(expectedCount: 0) { completed in
@@ -182,7 +185,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -229,7 +233,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -276,7 +281,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -329,7 +335,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -385,7 +392,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation { completed in
@@ -437,7 +445,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation(expectedCount: 0) { completed in
@@ -495,7 +504,8 @@ struct SurveyManagerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: nil,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
 
     await confirmation(expectedCount: 0) { completed in

--- a/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
+++ b/Tests/SuperwallKitTests/Web/WebEntitlementRedeemerTests.swift
@@ -315,7 +315,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -430,7 +431,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -949,7 +951,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -1122,7 +1125,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -1304,7 +1308,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -1488,7 +1493,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -1666,7 +1672,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"
@@ -1830,7 +1837,8 @@ struct WebEntitlementRedeemerTests {
       webView: webView,
       webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
       cache: cache,
-      paywallArchiveManager: nil
+      paywallArchiveManager: nil,
+      customCallbackRegistry: dependencyContainer.customCallbackRegistry
     )
     cache.save(paywallVc, forKey: "key")
     cache.activePaywallVcKey = "key"


### PR DESCRIPTION
## Changes in this pull request

- Adds an optional `onCustomCallback` parameter to `Superwall.getPaywall(forPlacement:params:paywallOverrides:delegate:onCustomCallback:)` so paywalls retrieved for embedding can handle custom webview callbacks. Previously this was only wired up through `register()`, which presents the paywall in its own `UIWindow` — embedding code (e.g. SwiftUI onboarding flows that need to layer their own UI over the paywall) had no way to receive callbacks and the webview always got a failure result.
- Extends `PaywallViewControllerDelegateAdapter` with an `onCustomCallback` closure and registers/unregisters it with the existing `CustomCallbackRegistry` from `PaywallViewController` (init, `delegate.didSet`, deinit). Reuses the same registry as the `register()` path, so the underlying message-handler dispatch in `PaywallMessageHandler.handleRequestCallback` is unchanged.
- Bumps version to 4.15.1 (Constants.swift, podspec, CHANGELOG).
- Motivated by Pylon #18179.

### Tests

Adds `CustomCallbackGetPaywallTests` with 4 tests covering: handler registered when adapter has one; no registration when handler is `nil`; reassigning the delegate updates registration (and `delegate = nil` clears it); deinit unregisters. Updates existing test mocks (`SurveyManagerTests`, `PresentPaywallOperatorTests`, `WebEntitlementRedeemerTests`, `TrackingLogicTests`) to pass the new `customCallbackRegistry:` init parameter.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `onCustomCallback` through `getPaywall()` so embedded paywalls can receive custom webview callback results instead of always getting a failure. It extends `PaywallViewControllerDelegateAdapter` with the closure and manages registration/unregistration with the shared `CustomCallbackRegistry` via a new `syncCustomCallbackRegistration()` helper called from `init`, `delegate.didSet`, and `deinit`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the one concern is a low-probability cross-path interference scenario that is a P2 design suggestion, not a blocking defect.

All findings are P2. The unconditional `unregister` in `deinit` / `syncCustomCallbackRegistration()` only becomes a problem when both `register()` and `getPaywall()` are used simultaneously with the same paywall identifier, which is an unusual usage pattern. Core logic, threading, and test coverage are all solid.

`PaywallViewController.swift` — the `syncCustomCallbackRegistration` / `deinit` unregister interaction warrants a second look if the two presentation paths are ever exercised concurrently on the same paywall identifier.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift | Adds `customCallbackRegistry` dependency and `syncCustomCallbackRegistration()`; the unconditional `unregister` in `deinit` and the `else` branch can silently evict a handler registered by the `register()` path. |
| Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift | Adds `onCustomCallback` closure to the adapter with a default-nil init parameter; clean, minimal change. |
| Sources/SuperwallKit/Paywall/Presentation/Get Paywall/PublicGetPaywall.swift | Threads new `onCustomCallback` parameter through both the completion-block and async `getPaywall` overloads; properly defaults to `nil` for backwards compatibility. |
| Tests/SuperwallKitTests/Paywall/Presentation/CustomCallbackRegistryTests.swift | New test suite covering registration on init, nil handler, delegate reassignment, and deinit unregistration — good coverage of the happy paths. |
| Sources/SuperwallKit/Dependencies/DependencyContainer.swift | Passes `customCallbackRegistry` to `PaywallViewController` init; mechanical, correct change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Superwall
    participant PaywallViewControllerDelegateAdapter
    participant PaywallViewController
    participant CustomCallbackRegistry
    participant WebView

    Caller->>Superwall: getPaywall(forPlacement:onCustomCallback:)
    Superwall->>PaywallViewControllerDelegateAdapter: init(swiftDelegate:objcDelegate:onCustomCallback:)
    Superwall->>PaywallViewController: init(...customCallbackRegistry:)
    PaywallViewController->>PaywallViewController: syncCustomCallbackRegistration()
    PaywallViewController->>CustomCallbackRegistry: register(paywallIdentifier:handler:)

    Caller->>Caller: embed / present PaywallViewController

    WebView->>PaywallMessageHandler: handleRequestCallback
    PaywallMessageHandler->>CustomCallbackRegistry: getHandler(paywallIdentifier:)
    CustomCallbackRegistry-->>PaywallMessageHandler: handler closure
    PaywallMessageHandler->>PaywallViewControllerDelegateAdapter: onCustomCallback(callback)
    PaywallViewControllerDelegateAdapter-->>PaywallMessageHandler: CustomCallbackResult

    Caller->>PaywallViewController: delegate = nil / deinit
    PaywallViewController->>CustomCallbackRegistry: unregister(paywallIdentifier:)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
Line: 292-295

Comment:
**Unconditional `unregister` in `deinit` may evict a `register()` handler**

`deinit` always calls `customCallbackRegistry.unregister(paywallIdentifier:)`, even when this VC was created via `getPaywall()` with `onCustomCallback: nil` (i.e., it never registered anything). The same applies to the `else` branch in `syncCustomCallbackRegistration()`. Because the registry is shared with the `register()` path, a sequence like:

1. `register()` presents paywall "abc" → handler stored under key "abc"
2. `getPaywall()` is called for the same paywall without `onCustomCallback` → `syncCustomCallbackRegistration()` calls `unregister("abc")`, silently evicting the live `register()` handler

A guard that only unregisters when this VC actually owns the current registration would prevent the cross-path interference:

```swift
private var hasRegisteredCallback = false

private func syncCustomCallbackRegistration() {
  if let handler = delegate?.onCustomCallback {
    customCallbackRegistry.register(paywallIdentifier: paywall.identifier, handler: handler)
    hasRegisteredCallback = true
  } else if hasRegisteredCallback {
    customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
    hasRegisteredCallback = false
  }
}

deinit {
  introOfferTokenManager.stopObservingAppLifecycle()
  if hasRegisteredCallback {
    customCallbackRegistry.unregister(paywallIdentifier: paywall.identifier)
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Wire custom callbacks through getPaywall"](https://github.com/superwall/superwall-ios/commit/3a769861c8d7b0855e4def5826f0663468b2e1c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29301345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->