### PR TITLE
Accept asset catalog entries in localResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds an `onCustomCallback` parameter to `getPaywall`.
-- `SuperwallOptions.localResources` now accepts `AssetResource` values, so paywall assets can be registered from an asset catalog (`.xcassets` Data Sets) via `CatalogAsset(name:bundle:)` in addition to file URLs. `URL` conforms to `AssetResource`, so existing call sites are unaffected.
+- `SuperwallOptions.localResources` now accepts UIImage's from xcasset files, e.g. `UIImage(named: "my-image")`.
 
 ## 4.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Adds an `onCustomCallback` parameter to `getPaywall`.
+- `SuperwallOptions.localResources` now accepts `AssetResource` values, so paywall assets can be registered from an asset catalog (`.xcassets` Data Sets) via `CatalogAsset(name:bundle:)` in addition to file URLs. `URL` conforms to `AssetResource`, so existing call sites are unaffected.
 
 ## 4.15.0
 

--- a/Sources/SuperwallKit/Config/ConfigLogic.swift
+++ b/Sources/SuperwallKit/Config/ConfigLogic.swift
@@ -306,8 +306,7 @@ enum ConfigLogic {
     from config: Config
   ) -> [String: Set<Entitlement>] {
     return Dictionary(
-      config.products.map { ($0.id, $0.entitlements) },
-      uniquingKeysWith: { $0.union($1) }
-    )
+      config.products.map { ($0.id, $0.entitlements) }
+    ) { $0.union($1) }
   }
 }

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -15,15 +15,13 @@ import UIKit
 ///
 /// Conforming types:
 /// - `URL` — a file on disk.
-/// - `UIImage` — re-encoded as PNG when served to the webview.
-/// - ``CatalogAsset`` — a deferred lookup against an `.xcassets` entry. Handles
-///   both Image Sets and Data Sets (video, Lottie JSON, etc.).
+/// - `UIImage` — re-encoded as PNG when served to the webview. Use this to
+///   register an asset catalog Image Set: `UIImage(named: "Logo")!`.
 ///
 /// ```swift
 /// options.localResources = [
 ///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!,
-///   "logo":       UIImage(named: "Logo")!,
-///   "hero-video": CatalogAsset(name: "HeroVideo")
+///   "logo":       UIImage(named: "Logo")!
 /// ]
 /// ```
 public protocol AssetResource {}
@@ -33,31 +31,3 @@ extension URL: AssetResource {}
 #if canImport(UIKit)
 extension UIImage: AssetResource {}
 #endif
-
-/// An entry in an asset catalog (`.xcassets`).
-///
-/// Resolved at load time by trying `UIImage(named:in:compatibleWith:)` first
-/// (Image Set, re-encoded as PNG), then falling back to
-/// `NSDataAsset(name:bundle:)` (Data Set, raw bytes preserved with no
-/// re-encoding).
-///
-/// Use a Data Set for non-image content (video, Lottie JSON, etc.) or when
-/// you need lossless bytes. Image Sets work as-is for typical paywall imagery
-/// like logos and icons.
-public struct CatalogAsset: AssetResource {
-  /// The name of the data asset as it appears in the asset catalog.
-  public let name: String
-
-  /// The bundle that contains the asset catalog.
-  public let bundle: Bundle
-
-  /// Creates a reference to a Data Set entry in an asset catalog.
-  ///
-  /// - Parameters:
-  ///   - name: The name of the data asset as it appears in the asset catalog.
-  ///   - bundle: The bundle that contains the asset catalog. Defaults to `.main`.
-  public init(name: String, bundle: Bundle = .main) {
-    self.name = name
-    self.bundle = bundle
-  }
-}

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-#if canImport(UIKit)
-import UIKit
-#endif
 
 /// A type that can be registered against ``SuperwallOptions/localResources`` and
 /// served to the paywall webview via the `swlocal://` URL scheme.

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -26,15 +26,14 @@ extension URL: AssetResource {}
 
 /// An entry in an asset catalog (`.xcassets`).
 ///
-/// Resolved at load time by trying `NSDataAsset(name:bundle:)` first (Data Set,
-/// raw bytes preserved with no re-encoding), then falling back to
-/// `UIImage(named:in:compatibleWith:)` re-encoded as PNG (Image Set).
+/// Resolved at load time by trying `UIImage(named:in:compatibleWith:)` first
+/// (Image Set, re-encoded as PNG), then falling back to
+/// `NSDataAsset(name:bundle:)` (Data Set, raw bytes preserved with no
+/// re-encoding).
 ///
-/// Prefer a Data Set if you can — it's lossless and works for any file type
-/// (images, video, Lottie JSON, etc.). The Image Set fallback exists so an
-/// existing `Logo` or icon Image Set "just works" without restructuring your
-/// asset catalog, but be aware: it picks a single scale variant and encodes
-/// to PNG, which can be larger than the original asset.
+/// Use a Data Set for non-image content (video, Lottie JSON, etc.) or when
+/// you need lossless bytes. Image Sets work as-is for typical paywall imagery
+/// like logos and icons.
 public struct CatalogAsset: AssetResource {
   /// The name of the data asset as it appears in the asset catalog.
   public let name: String

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -1,0 +1,54 @@
+//
+//  AssetResource.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 24/04/2026.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// A type that can be registered against ``SuperwallOptions/localResources`` and
+/// served to the paywall webview via the `swlocal://` URL scheme.
+///
+/// `URL` conforms out of the box, so existing call sites registering file URLs
+/// keep working. To register an asset from an `.xcassets` Data Set (the iOS
+/// equivalent of Android's `R.raw.*` resource IDs), use ``CatalogAsset``.
+///
+/// ```swift
+/// options.localResources = [
+///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!,
+///   "hero-video": CatalogAsset(name: "HeroVideo")
+/// ]
+/// ```
+public protocol AssetResource {}
+
+extension URL: AssetResource {}
+
+/// An entry in an asset catalog (`.xcassets`) stored as a Data Set.
+///
+/// Resolved at load time via `NSDataAsset(name:bundle:)`, so the raw bytes are
+/// preserved without re-encoding. Use this when you want to ship paywall assets
+/// inside your `.xcassets` instead of as loose files in the bundle.
+///
+/// - Note: Add the asset to your `.xcassets` as a **Data Set** (not an Image Set)
+///   so `NSDataAsset` can read it and the webview receives the bytes verbatim.
+public struct CatalogAsset: AssetResource {
+  /// The name of the data asset as it appears in the asset catalog.
+  public let name: String
+
+  /// The bundle that contains the asset catalog.
+  public let bundle: Bundle
+
+  /// Creates a reference to a Data Set entry in an asset catalog.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the data asset as it appears in the asset catalog.
+  ///   - bundle: The bundle that contains the asset catalog. Defaults to `.main`.
+  public init(name: String, bundle: Bundle = .main) {
+    self.name = name
+    self.bundle = bundle
+  }
+}

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -24,14 +24,17 @@ public protocol AssetResource {}
 
 extension URL: AssetResource {}
 
-/// An entry in an asset catalog (`.xcassets`) stored as a Data Set.
+/// An entry in an asset catalog (`.xcassets`).
 ///
-/// Resolved at load time via `NSDataAsset(name:bundle:)`, so the raw bytes are
-/// preserved without re-encoding. Use this when you want to ship paywall assets
-/// inside your `.xcassets` instead of as loose files in the bundle.
+/// Resolved at load time by trying `NSDataAsset(name:bundle:)` first (Data Set,
+/// raw bytes preserved with no re-encoding), then falling back to
+/// `UIImage(named:in:compatibleWith:)` re-encoded as PNG (Image Set).
 ///
-/// - Note: Add the asset to your `.xcassets` as a **Data Set** (not an Image Set)
-///   so `NSDataAsset` can read it and the webview receives the bytes verbatim.
+/// Prefer a Data Set if you can — it's lossless and works for any file type
+/// (images, video, Lottie JSON, etc.). The Image Set fallback exists so an
+/// existing `Logo` or icon Image Set "just works" without restructuring your
+/// asset catalog, but be aware: it picks a single scale variant and encodes
+/// to PNG, which can be larger than the original asset.
 public struct CatalogAsset: AssetResource {
   /// The name of the data asset as it appears in the asset catalog.
   public let name: String

--- a/Sources/SuperwallKit/Config/Options/AssetResource.swift
+++ b/Sources/SuperwallKit/Config/Options/AssetResource.swift
@@ -6,23 +6,33 @@
 //
 
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// A type that can be registered against ``SuperwallOptions/localResources`` and
 /// served to the paywall webview via the `swlocal://` URL scheme.
 ///
-/// `URL` conforms out of the box, so existing call sites registering file URLs
-/// keep working. To register an asset from an `.xcassets` Data Set (the iOS
-/// equivalent of Android's `R.raw.*` resource IDs), use ``CatalogAsset``.
+/// Conforming types:
+/// - `URL` — a file on disk.
+/// - `UIImage` — re-encoded as PNG when served to the webview.
+/// - ``CatalogAsset`` — a deferred lookup against an `.xcassets` entry. Handles
+///   both Image Sets and Data Sets (video, Lottie JSON, etc.).
 ///
 /// ```swift
 /// options.localResources = [
 ///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!,
+///   "logo":       UIImage(named: "Logo")!,
 ///   "hero-video": CatalogAsset(name: "HeroVideo")
 /// ]
 /// ```
 public protocol AssetResource {}
 
 extension URL: AssetResource {}
+
+#if canImport(UIKit)
+extension UIImage: AssetResource {}
+#endif
 
 /// An entry in an asset catalog (`.xcassets`).
 ///

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -44,6 +44,10 @@ public final class SuperwallOptions: NSObject, Encodable {
 
   /// Objective-C bridge for ``localResources``. Exposed to ObjC under the name
   /// `localResources` and limited to `URL` values (asset-catalog entries are Swift-only).
+  ///
+  /// The setter replaces only the URL subset of ``localResources``; any
+  /// `CatalogAsset` entries previously registered from Swift are preserved so
+  /// they are not silently dropped by an ObjC assignment.
   @available(swift, obsoleted: 1.0)
   @objc(localResources)
   public var localResourcesObjC: [String: URL] {
@@ -51,7 +55,11 @@ public final class SuperwallOptions: NSObject, Encodable {
       return localResources.compactMapValues { $0 as? URL }
     }
     set {
-      localResources = newValue.mapValues { $0 as AssetResource }
+      var merged: [String: AssetResource] = localResources.filter { !($0.value is URL) }
+      for (key, url) in newValue {
+        merged[key] = url
+      }
+      localResources = merged
     }
   }
 

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -7,6 +7,9 @@
 // swiftlint:disable file_length
 
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Options for configuring Superwall, including paywall presentation and appearance.
 ///
@@ -26,8 +29,8 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// references a `localResourceId`, the SDK looks up the corresponding entry here and
   /// serves it via the `swlocal://` URL scheme.
   ///
-  /// `URL` conforms to ``AssetResource`` so file-URL call sites keep working. Register
-  /// entries from an `.xcassets` Data Set with ``CatalogAsset``.
+  /// `URL` conforms to ``AssetResource`` so file-URL call sites keep working. Register an
+  /// `.xcassets` Image Set by passing a `UIImage`.
   ///
   /// Set this before calling ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``
   /// to ensure resources are available before any paywall can trigger (e.g. on `app_launch`).
@@ -35,23 +38,43 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// ```swift
   /// let options = SuperwallOptions()
   /// options.localResources = [
-  ///   "hero-video": CatalogAsset(name: "OnboardingHero"),
+  ///   "logo":       UIImage(named: "Logo")!,
   ///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!
   /// ]
   /// Superwall.configure(apiKey: "your-api-key", options: options)
   /// ```
   @nonobjc public var localResources: [String: AssetResource] = [:]
 
-  /// Objective-C bridge for ``localResources``. Exposed to ObjC under the name
-  /// `localResources` and limited to `URL` values (asset-catalog entries are Swift-only).
+  /// Objective-C bridge for ``localResources``. Accepts `NSURL` and `UIImage` values;
+  /// any other type is dropped.
   @available(swift, obsoleted: 1.0)
   @objc(localResources)
-  public var localResourcesObjC: [String: URL] {
+  public var localResourcesObjC: [String: NSObject] {
     get {
-      return localResources.compactMapValues { $0 as? URL }
+      return localResources.compactMapValues { resource in
+        if let url = resource as? URL {
+          return url as NSURL
+        }
+        #if canImport(UIKit)
+        if let image = resource as? UIImage {
+          return image
+        }
+        #endif
+        return nil
+      }
     }
     set {
-      localResources = newValue.mapValues { $0 as AssetResource }
+      localResources = newValue.compactMapValues { value in
+        if let url = value as? URL {
+          return url
+        }
+        #if canImport(UIKit)
+        if let image = value as? UIImage {
+          return image
+        }
+        #endif
+        return nil
+      }
     }
   }
 

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -45,8 +45,8 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// ```
   @nonobjc public var localResources: [String: AssetResource] = [:]
 
-  /// Objective-C bridge for ``localResources``. Accepts `NSURL` and `UIImage` values;
-  /// any other type is dropped.
+  /// Objective-C bridge for ``localResources``. Accepts `NSURL` and `UIImage` values
+  /// (mirroring the Swift surface); any other value type is dropped.
   @available(swift, obsoleted: 1.0)
   @objc(localResources)
   public var localResourcesObjC: [String: NSObject] {

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -44,10 +44,6 @@ public final class SuperwallOptions: NSObject, Encodable {
 
   /// Objective-C bridge for ``localResources``. Exposed to ObjC under the name
   /// `localResources` and limited to `URL` values (asset-catalog entries are Swift-only).
-  ///
-  /// The setter replaces only the URL subset of ``localResources``; any
-  /// `CatalogAsset` entries previously registered from Swift are preserved so
-  /// they are not silently dropped by an ObjC assignment.
   @available(swift, obsoleted: 1.0)
   @objc(localResources)
   public var localResourcesObjC: [String: URL] {
@@ -55,11 +51,7 @@ public final class SuperwallOptions: NSObject, Encodable {
       return localResources.compactMapValues { $0 as? URL }
     }
     set {
-      var merged: [String: AssetResource] = localResources.filter { !($0.value is URL) }
-      for (key, url) in newValue {
-        merged[key] = url
-      }
-      localResources = merged
+      localResources = newValue.mapValues { $0 as AssetResource }
     }
   }
 

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 11/07/2022.
 //
+// swiftlint:disable file_length
 
 import Foundation
 
@@ -11,18 +12,22 @@ import Foundation
 ///
 /// Pass an instance of this class to
 /// ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``.
+// swiftlint:disable type_body_length
 @objc(SWKSuperwallOptions)
 @objcMembers
 public final class SuperwallOptions: NSObject, Encodable {
   /// Configures the appearance and behaviour of paywalls.
   public var paywalls = PaywallOptions()
 
-  /// A mapping of local resource IDs to local file URLs.
+  /// A mapping of local resource IDs to ``AssetResource`` values.
   ///
-  /// Use this to serve paywall assets (images, videos, Lottie animations) from local files
-  /// instead of fetching them over the network. When a paywall references a `localResourceId`,
-  /// the SDK will look up the corresponding URL in this dictionary and serve the file via the
-  /// `swlocal://` URL scheme.
+  /// Use this to serve paywall assets (images, videos, Lottie animations) from the app
+  /// bundle or an asset catalog instead of fetching them over the network. When a paywall
+  /// references a `localResourceId`, the SDK looks up the corresponding entry here and
+  /// serves it via the `swlocal://` URL scheme.
+  ///
+  /// `URL` conforms to ``AssetResource`` so file-URL call sites keep working. Register
+  /// entries from an `.xcassets` Data Set with ``CatalogAsset``.
   ///
   /// Set this before calling ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``
   /// to ensure resources are available before any paywall can trigger (e.g. on `app_launch`).
@@ -30,12 +35,25 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// ```swift
   /// let options = SuperwallOptions()
   /// options.localResources = [
-  ///   "hero-video": Bundle.main.url(forResource: "onboarding", withExtension: "mp4")!,
+  ///   "hero-video": CatalogAsset(name: "OnboardingHero"),
   ///   "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!
   /// ]
   /// Superwall.configure(apiKey: "your-api-key", options: options)
   /// ```
-  public var localResources: [String: URL] = [:]
+  @nonobjc public var localResources: [String: AssetResource] = [:]
+
+  /// Objective-C bridge for ``localResources``. Exposed to ObjC under the name
+  /// `localResources` and limited to `URL` values (asset-catalog entries are Swift-only).
+  @available(swift, obsoleted: 1.0)
+  @objc(localResources)
+  public var localResourcesObjC: [String: URL] {
+    get {
+      return localResources.compactMapValues { $0 as? URL }
+    }
+    set {
+      localResources = newValue.mapValues { $0 as AssetResource }
+    }
+  }
 
   /// Controls when the SDK enters test mode.
   @objc(SWKTestModeBehavior)

--- a/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
+++ b/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
@@ -238,8 +238,6 @@ private final class LocalResourceCell: UICollectionViewCell {
       idLabel.text = "\(id) (UIImage)"
       spinner.stopAnimating()
       imageView.image = image
-    } else if let catalog = resource as? CatalogAsset {
-      configureCatalogAsset(id: id, catalog: catalog)
     } else {
       idLabel.text = id
       showErrorText("Unsupported resource type")
@@ -260,35 +258,6 @@ private final class LocalResourceCell: UICollectionViewCell {
       spinner.stopAnimating()
       if !FileManager.default.fileExists(atPath: url.path) {
         showErrorText("File not found")
-      }
-    }
-  }
-
-  private func configureCatalogAsset(id: String, catalog: CatalogAsset) {
-    idLabel.text = "\(id) (asset: \(catalog.name))"
-    spinner.startAnimating()
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-      // Mirror LocalFileSchemeHandler resolution order so Image Sets preview correctly.
-      if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil) {
-        DispatchQueue.main.async {
-          self?.spinner.stopAnimating()
-          self?.imageView.image = image
-        }
-        return
-      }
-
-      let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle)
-      let image = asset.flatMap { UIImage(data: $0.data) }
-      DispatchQueue.main.async {
-        self?.spinner.stopAnimating()
-        if let image = image {
-          self?.imageView.image = image
-        } else if let asset = asset {
-          let byteCount = ByteCountFormatter.string(fromByteCount: Int64(asset.data.count), countStyle: .file)
-          self?.showErrorText("No preview\n\(asset.typeIdentifier) · \(byteCount)")
-        } else {
-          self?.showErrorText("Asset not found")
-        }
       }
     }
   }

--- a/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
+++ b/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
@@ -234,6 +234,10 @@ private final class LocalResourceCell: UICollectionViewCell {
   func configure(id: String, resource: AssetResource) {
     if let url = resource as? URL {
       configureURL(id: id, url: url)
+    } else if let image = resource as? UIImage {
+      idLabel.text = "\(id) (UIImage)"
+      spinner.stopAnimating()
+      imageView.image = image
     } else if let catalog = resource as? CatalogAsset {
       configureCatalogAsset(id: id, catalog: catalog)
     } else {

--- a/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
+++ b/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
@@ -270,7 +270,10 @@ private final class LocalResourceCell: UICollectionViewCell {
         self?.spinner.stopAnimating()
         if let image = image {
           self?.imageView.image = image
-        } else if asset == nil {
+        } else if let asset = asset {
+          let byteCount = ByteCountFormatter.string(fromByteCount: Int64(asset.data.count), countStyle: .file)
+          self?.showErrorText("No preview\n\(asset.typeIdentifier) · \(byteCount)")
+        } else {
           self?.showErrorText("Asset not found")
         }
       }

--- a/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
+++ b/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
@@ -268,6 +268,15 @@ private final class LocalResourceCell: UICollectionViewCell {
     idLabel.text = "\(id) (asset: \(catalog.name))"
     spinner.startAnimating()
     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      // Mirror LocalFileSchemeHandler resolution order so Image Sets preview correctly.
+      if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil) {
+        DispatchQueue.main.async {
+          self?.spinner.stopAnimating()
+          self?.imageView.image = image
+        }
+        return
+      }
+
       let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle)
       let image = asset.flatMap { UIImage(data: $0.data) }
       DispatchQueue.main.async {

--- a/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
+++ b/Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 import AVFoundation
 
 final class SWLocalResourcesViewController: UICollectionViewController {
-  private var resources: [(id: String, url: URL)] = []
+  private var resources: [(id: String, resource: AssetResource)] = []
 
   init() {
     let layout = UICollectionViewFlowLayout()
@@ -53,7 +53,7 @@ final class SWLocalResourcesViewController: UICollectionViewController {
 
     resources = Superwall.shared.options.localResources
       .sorted { $0.key < $1.key }
-      .map { (id: $0.key, url: $0.value) }
+      .map { (id: $0.key, resource: $0.value) }
   }
 
   @objc private func doneTapped() {
@@ -86,7 +86,7 @@ final class SWLocalResourcesViewController: UICollectionViewController {
     // swiftlint:disable:next force_cast
     ) as! LocalResourceCell
     let resource = resources[indexPath.item]
-    cell.configure(id: resource.id, url: resource.url)
+    cell.configure(id: resource.id, resource: resource.resource)
     return cell
   }
 }
@@ -231,7 +231,18 @@ private final class LocalResourceCell: UICollectionViewCell {
     spinner.stopAnimating()
   }
 
-  func configure(id: String, url: URL) {
+  func configure(id: String, resource: AssetResource) {
+    if let url = resource as? URL {
+      configureURL(id: id, url: url)
+    } else if let catalog = resource as? CatalogAsset {
+      configureCatalogAsset(id: id, catalog: catalog)
+    } else {
+      idLabel.text = id
+      showErrorText("Unsupported resource type")
+    }
+  }
+
+  private func configureURL(id: String, url: URL) {
     let ext = url.pathExtension.lowercased()
     idLabel.text = ext.isEmpty ? id : "\(id).\(ext)"
     spinner.startAnimating()
@@ -245,6 +256,23 @@ private final class LocalResourceCell: UICollectionViewCell {
       spinner.stopAnimating()
       if !FileManager.default.fileExists(atPath: url.path) {
         showErrorText("File not found")
+      }
+    }
+  }
+
+  private func configureCatalogAsset(id: String, catalog: CatalogAsset) {
+    idLabel.text = "\(id) (asset: \(catalog.name))"
+    spinner.startAnimating()
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle)
+      let image = asset.flatMap { UIImage(data: $0.data) }
+      DispatchQueue.main.async {
+        self?.spinner.stopAnimating()
+        if let image = image {
+          self?.imageView.image = image
+        } else if asset == nil {
+          self?.showErrorText("Asset not found")
+        }
       }
     }
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 import WebKit
+#if canImport(UIKit)
+import UIKit
+#endif
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+#endif
 
 /// Handles custom URL scheme requests for serving local files to the paywall webview.
 ///
@@ -83,7 +89,8 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
 
   // MARK: - File Loading
 
-  /// Loads a file from `SuperwallOptions.localResources` based on the URL host (the localResourceId).
+  /// Loads a file from `SuperwallOptions.localResources` based on the URL host
+  /// (the localResourceId).
   /// - Parameter url: The swlocal:// URL where the host is the localResourceId
   /// - Returns: Tuple of file data and MIME type
   func loadFile(from url: URL) throws -> (Data, String) {
@@ -91,16 +98,44 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
       throw FileError.invalidURL
     }
 
-    guard let localURL = Superwall.shared.options.localResources[host] else {
+    guard let resource = Superwall.shared.options.localResources[host] else {
       throw FileError.fileNotFound(host)
     }
 
+    return try load(resource: resource, key: host)
+  }
+
+  /// Resolves an ``AssetResource`` to its data and MIME type.
+  private func load(resource: AssetResource, key: String) throws -> (Data, String) {
+    if let localURL = resource as? URL {
+      return try loadFile(at: localURL)
+    }
+    if let catalog = resource as? CatalogAsset {
+      guard let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) else {
+        throw FileError.fileNotFound("\(key) (data asset \(catalog.name))")
+      }
+      return (asset.data, mimeType(forUTI: asset.typeIdentifier))
+    }
+    throw FileError.fileNotFound(key)
+  }
+
+  private func loadFile(at localURL: URL) throws -> (Data, String) {
     guard let data = try? Data(contentsOf: localURL) else {
       throw FileError.unableToReadFile(localURL.path)
     }
+    return (data, mimeType(for: localURL.pathExtension))
+  }
 
-    let mimeType = self.mimeType(for: localURL.pathExtension)
-    return (data, mimeType)
+  /// Maps a UTI (e.g. `public.png`, `public.mpeg-4`) to a MIME type.
+  /// Falls back to `application/octet-stream` if the UTI can't be resolved.
+  private func mimeType(forUTI uti: String) -> String {
+    if #available(iOS 14.0, *) {
+      if let type = UTType(uti),
+        let mime = type.preferredMIMEType {
+        return mime
+      }
+    }
+    return "application/octet-stream"
   }
 
   // MARK: - MIME Type Detection

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -32,7 +32,8 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
 
   #if canImport(UIKit)
   /// Caches PNG-encoded bytes per `UIImage` so repeat webview requests skip re-encoding.
-  private let imageDataCache = NSCache<UIImage, NSData>()
+  /// Shared across handler instances so reuse across paywalls also hits the cache.
+  private static let imageDataCache = NSCache<UIImage, NSData>()
   #endif
 
   /// Errors that can occur during file loading
@@ -114,13 +115,13 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
     }
     #if canImport(UIKit)
     if let image = resource as? UIImage {
-      if let cached = imageDataCache.object(forKey: image) {
+      if let cached = Self.imageDataCache.object(forKey: image) {
         return (cached as Data, "image/png")
       }
       guard let data = image.pngData() else {
         throw FileError.unableToReadFile("\(key) (UIImage pngData nil)")
       }
-      imageDataCache.setObject(data as NSData, forKey: image)
+      Self.imageDataCache.setObject(data as NSData, forKey: image)
       return (data, "image/png")
     }
     #endif

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -114,15 +114,15 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
       return try loadFile(at: localURL)
     }
     if let catalog = resource as? CatalogAsset {
-      if let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) {
-        return (asset.data, mimeType(forUTI: asset.typeIdentifier))
-      }
       #if canImport(UIKit)
       if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil),
         let data = image.pngData() {
         return (data, "image/png")
       }
       #endif
+      if let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) {
+        return (asset.data, mimeType(forUTI: asset.typeIdentifier))
+      }
       throw FileError.fileNotFound("\(key) (asset \(catalog.name))")
     }
     throw FileError.fileNotFound(key)

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -113,6 +113,14 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
     if let localURL = resource as? URL {
       return try loadFile(at: localURL)
     }
+    #if canImport(UIKit)
+    if let image = resource as? UIImage {
+      guard let data = image.pngData() else {
+        throw FileError.unableToReadFile("\(key) (UIImage pngData nil)")
+      }
+      return (data, "image/png")
+    }
+    #endif
     if let catalog = resource as? CatalogAsset {
       #if canImport(UIKit)
       if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil),

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -10,12 +10,6 @@ import WebKit
 #if canImport(UIKit)
 import UIKit
 #endif
-#if canImport(UniformTypeIdentifiers)
-import UniformTypeIdentifiers
-#endif
-#if canImport(MobileCoreServices)
-import MobileCoreServices
-#endif
 
 /// Handles custom URL scheme requests for serving local files to the paywall webview.
 ///
@@ -121,18 +115,6 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
       return (data, "image/png")
     }
     #endif
-    if let catalog = resource as? CatalogAsset {
-      #if canImport(UIKit)
-      if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil),
-        let data = image.pngData() {
-        return (data, "image/png")
-      }
-      #endif
-      if let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) {
-        return (asset.data, mimeType(forUTI: asset.typeIdentifier))
-      }
-      throw FileError.fileNotFound("\(key) (asset \(catalog.name))")
-    }
     throw FileError.fileNotFound(key)
   }
 
@@ -141,24 +123,6 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
       throw FileError.unableToReadFile(localURL.path)
     }
     return (data, mimeType(for: localURL.pathExtension))
-  }
-
-  /// Maps a UTI (e.g. `public.png`, `public.mpeg-4`) to a MIME type.
-  /// Falls back to `application/octet-stream` if the UTI can't be resolved.
-  private func mimeType(forUTI uti: String) -> String {
-    if #available(iOS 14.0, *) {
-      if let type = UTType(uti),
-        let mime = type.preferredMIMEType {
-        return mime
-      }
-    } else {
-      let cfUTI = uti as CFString
-      if let mime = UTTypeCopyPreferredTagWithClass(cfUTI, kUTTagClassMIMEType)?
-        .takeRetainedValue() as String? {
-        return mime
-      }
-    }
-    return "application/octet-stream"
   }
 
   // MARK: - MIME Type Detection

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -30,6 +30,11 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
   /// The custom URL scheme for local files
   static let scheme = "swlocal"
 
+  #if canImport(UIKit)
+  /// Caches PNG-encoded bytes per `UIImage` so repeat webview requests skip re-encoding.
+  private let imageDataCache = NSCache<UIImage, NSData>()
+  #endif
+
   /// Errors that can occur during file loading
   enum FileError: LocalizedError, Equatable {
     case invalidURL
@@ -109,9 +114,13 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
     }
     #if canImport(UIKit)
     if let image = resource as? UIImage {
+      if let cached = imageDataCache.object(forKey: image) {
+        return (cached as Data, "image/png")
+      }
       guard let data = image.pngData() else {
         throw FileError.unableToReadFile("\(key) (UIImage pngData nil)")
       }
+      imageDataCache.setObject(data as NSData, forKey: image)
       return (data, "image/png")
     }
     #endif

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 import WebKit
+#if canImport(UIKit)
+import UIKit
+#endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 #endif
@@ -111,10 +114,16 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
       return try loadFile(at: localURL)
     }
     if let catalog = resource as? CatalogAsset {
-      guard let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) else {
-        throw FileError.fileNotFound("\(key) (data asset \(catalog.name))")
+      if let asset = NSDataAsset(name: catalog.name, bundle: catalog.bundle) {
+        return (asset.data, mimeType(forUTI: asset.typeIdentifier))
       }
-      return (asset.data, mimeType(forUTI: asset.typeIdentifier))
+      #if canImport(UIKit)
+      if let image = UIImage(named: catalog.name, in: catalog.bundle, compatibleWith: nil),
+        let data = image.pngData() {
+        return (data, "image/png")
+      }
+      #endif
+      throw FileError.fileNotFound("\(key) (asset \(catalog.name))")
     }
     throw FileError.fileNotFound(key)
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -7,9 +7,6 @@
 
 import Foundation
 import WebKit
-#if canImport(UIKit)
-import UIKit
-#endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 #endif

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift
@@ -13,6 +13,9 @@ import UIKit
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 #endif
+#if canImport(MobileCoreServices)
+import MobileCoreServices
+#endif
 
 /// Handles custom URL scheme requests for serving local files to the paywall webview.
 ///
@@ -132,6 +135,12 @@ final class LocalFileSchemeHandler: NSObject, WKURLSchemeHandler {
     if #available(iOS 14.0, *) {
       if let type = UTType(uti),
         let mime = type.preferredMIMEType {
+        return mime
+      }
+    } else {
+      let cfUTI = uti as CFString
+      if let mime = UTTypeCopyPreferredTagWithClass(cfUTI, kUTTagClassMIMEType)?
+        .takeRetainedValue() as String? {
         return mime
       }
     }

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		CE43399599386456DCCD1FDC /* FakeLocationAuthorizationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3529B422EB2D09B69265B591 /* FakeLocationAuthorizationStatusTests.swift */; };
 		CE5307A037FCFD8CB8380EB5 /* GetPaywallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3781CF21200CD2333F6779A /* GetPaywallManager.swift */; };
 		CE821667CB6676EA02510FE9 /* TrackingManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78C5C57C3C92444EBAC2E38 /* TrackingManagerProxy.swift */; };
+		CE85C4CC2D3E98738F2C37E7 /* AssetResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23307BBFD80385233DDD4C43 /* AssetResource.swift */; };
 		CEF9BBFFE0D64A011A59FB4C /* TestModeManagerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17DB6AB272712E9350966E4 /* TestModeManagerFactory.swift */; };
 		CF2064883604B915C8768FC5 /* ASIdManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF989B3D90DC3D88FACC4D45 /* ASIdManagerProxy.swift */; };
 		CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */; };
@@ -647,6 +648,7 @@
 		22439CFFFC5166F34D0DA524 /* WebViewURLConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewURLConfig.swift; sourceTree = "<group>"; };
 		22919EFD263425D38E7D9D38 /* WebEntitlementRedeemer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebEntitlementRedeemer.swift; sourceTree = "<group>"; };
 		22D96B4C9B546F7B0EC73397 /* PaywallViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerWrapper.swift; sourceTree = "<group>"; };
+		23307BBFD80385233DDD4C43 /* AssetResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetResource.swift; sourceTree = "<group>"; };
 		236900A8A8F95CE92E612458 /* IdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManager.swift; sourceTree = "<group>"; };
 		2378D0EF4F79DDF0BC45B389 /* FakeLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeLocationManager.swift; sourceTree = "<group>"; };
 		23886A83274F67B1DCB8573A /* SWWebViewLoadingHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWWebViewLoadingHandlerTests.swift; sourceTree = "<group>"; };
@@ -2906,6 +2908,7 @@
 		E7D208EAB24A633EB74B1E31 /* Options */ = {
 			isa = PBXGroup;
 			children = (
+				23307BBFD80385233DDD4C43 /* AssetResource.swift */,
 				B1A64CCBCB23CC1715DF79AC /* PaywallOptions.swift */,
 				CFDA311A030FDFC45AEE248A /* SuperwallOptions.swift */,
 			);
@@ -3323,6 +3326,7 @@
 				9DC74748B0DC9DA519E70FE6 /* Array+Capability.swift in Sources */,
 				F8E799A3A83A2758D6EAA385 /* Array+Guarded.swift in Sources */,
 				B0B0AD9409CEFE7CA8225146 /* Array+SafeRemove.swift in Sources */,
+				CE85C4CC2D3E98738F2C37E7 /* AssetResource.swift in Sources */,
 				2428529A6B2B6E873DEC22E8 /* Assignment.swift in Sources */,
 				75083E470EB6E25E01F4F28B /* AsyncSequence+Extract.swift in Sources */,
 				69D24C6E0411E512FECF7258 /* Attribution.swift in Sources */,

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
@@ -9,6 +9,7 @@
 import Testing
 @testable import SuperwallKit
 import Foundation
+import UIKit
 
 @Suite(.serialized)
 struct LocalFileSchemeHandlerTests {
@@ -129,6 +130,25 @@ struct LocalFileSchemeHandlerTests {
     let (data, mimeType) = try handler.loadFile(from: url)
     #expect(data == Data("png-bytes".utf8))
     #expect(mimeType == "image/png")
+
+    Superwall.shared.options.localResources = [:]
+  }
+
+  @Test("UIImage conforms to AssetResource and is served as image/png")
+  func loadFileUIImageConformance() throws {
+    let handler = LocalFileSchemeHandler()
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4))
+    let image = renderer.image { ctx in
+      UIColor.red.setFill()
+      ctx.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+    }
+
+    Superwall.shared.options.localResources = ["logo": image]
+    let url = URL(string: "swlocal://logo")!
+
+    let (data, mimeType) = try handler.loadFile(from: url)
+    #expect(mimeType == "image/png")
+    #expect(data == image.pngData())
 
     Superwall.shared.options.localResources = [:]
   }

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
@@ -101,21 +101,6 @@ struct LocalFileSchemeHandlerTests {
 
   // MARK: - AssetResource Tests
 
-  @Test("loadFile throws fileNotFound when CatalogAsset name is missing from bundle")
-  func loadFileMissingCatalogAsset() {
-    let handler = LocalFileSchemeHandler()
-    Superwall.shared.options.localResources = [
-      "hero-video": CatalogAsset(name: "ThisAssetDoesNotExist", bundle: .main)
-    ]
-    let url = URL(string: "swlocal://hero-video")!
-
-    #expect(throws: LocalFileSchemeHandler.FileError.fileNotFound("hero-video (asset ThisAssetDoesNotExist)")) {
-      try handler.loadFile(from: url)
-    }
-
-    Superwall.shared.options.localResources = [:]
-  }
-
   @Test("URL conforms to AssetResource and registers via the same dictionary")
   func loadFileURLConformance() throws {
     let handler = LocalFileSchemeHandler()

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
@@ -108,7 +108,7 @@ struct LocalFileSchemeHandlerTests {
     ]
     let url = URL(string: "swlocal://hero-video")!
 
-    #expect(throws: LocalFileSchemeHandler.FileError.fileNotFound("hero-video (data asset ThisAssetDoesNotExist)")) {
+    #expect(throws: LocalFileSchemeHandler.FileError.fileNotFound("hero-video (asset ThisAssetDoesNotExist)")) {
       try handler.loadFile(from: url)
     }
 

--- a/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift
@@ -98,6 +98,41 @@ struct LocalFileSchemeHandlerTests {
     Superwall.shared.options.localResources = [:]
   }
 
+  // MARK: - AssetResource Tests
+
+  @Test("loadFile throws fileNotFound when CatalogAsset name is missing from bundle")
+  func loadFileMissingCatalogAsset() {
+    let handler = LocalFileSchemeHandler()
+    Superwall.shared.options.localResources = [
+      "hero-video": CatalogAsset(name: "ThisAssetDoesNotExist", bundle: .main)
+    ]
+    let url = URL(string: "swlocal://hero-video")!
+
+    #expect(throws: LocalFileSchemeHandler.FileError.fileNotFound("hero-video (data asset ThisAssetDoesNotExist)")) {
+      try handler.loadFile(from: url)
+    }
+
+    Superwall.shared.options.localResources = [:]
+  }
+
+  @Test("URL conforms to AssetResource and registers via the same dictionary")
+  func loadFileURLConformance() throws {
+    let handler = LocalFileSchemeHandler()
+    let tempDir = FileManager.default.temporaryDirectory
+    let tempFile = tempDir.appendingPathComponent("asset-resource-url.png")
+    try Data("png-bytes".utf8).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    Superwall.shared.options.localResources = ["hero-image": tempFile]
+    let url = URL(string: "swlocal://hero-image")!
+
+    let (data, mimeType) = try handler.loadFile(from: url)
+    #expect(data == Data("png-bytes".utf8))
+    #expect(mimeType == "image/png")
+
+    Superwall.shared.options.localResources = [:]
+  }
+
   @Test("loadFile detects correct mime types from file extension")
   func loadFileMimeTypes() throws {
     let handler = LocalFileSchemeHandler()


### PR DESCRIPTION
## Changes in this pull request

Generalises `SuperwallOptions.localResources` from `[String: URL]` to `[String: AssetResource]` so customers can register paywall assets that live inside an asset catalog (`.xcassets`), achieving parity with the Android SDK's `PaywallResource.FromResources(R.drawable.*)`.

Customer ask (Pylon): customers whose assets live in `.xcassets` had no clean way to register them because asset catalog entries don't expose a file URL.

### API

New `AssetResource` protocol is the dictionary's value type. Two conforming types:

- `URL` — existing behavior, a file on disk. Conforms out of the box, so existing call sites that assign URL dictionaries compile and behave unchanged.
- `UIImage` — register an in-memory image directly; served to the webview as `image/png` via `pngData()`. This covers the asset catalog case via `UIImage(named: "Logo")`.

```swift
options.localResources = [
  "hero-image": Bundle.main.url(forResource: "hero", withExtension: "png")!,
  "logo":       UIImage(named: "Logo")!
]
```

### Implementation notes

- `LocalFileSchemeHandler` switches on the resource type. `URL` is read with `Data(contentsOf:)` and a MIME type derived from the path extension; `UIImage` is re-encoded via `pngData()` and served as `image/png`. The PNG bytes are cached per `UIImage` (`NSCache`) so repeat webview requests don't re-encode on the main thread.
- ObjC bridge (`@objc(localResources)`) is typed `[String: NSObject]` and accepts both `NSURL` and `UIImage` values; anything else is dropped. **Note:** the ObjC property's generic type widened from `NSDictionary<NSString *, NSURL *> *` to `NSDictionary<NSString *, NSObject *> *`. Setter assignments and dictionary literals continue to work; ObjC code that previously assigned the *getter* into an `NSDictionary<NSString *, NSURL *> *` local will now see an "incompatible pointer types" warning that's resolved by retyping the local or casting.
- `SWLocalResourcesViewController` (debug view) previews both URL and `UIImage` entries.
- Customers with non-image asset catalog entries (Data Sets — video, Lottie JSON, etc.) should continue to ship those as files on disk and register them via `URL`. Asset catalog support is scoped to images, which covers the Pylon ask.
- Unrelated cleanup: dropped a stale `trailing_closure` lint violation in `ConfigLogic.swift:310` while in the area.

### Tests

Extends `LocalFileSchemeHandlerTests`:

- `URL` registered through the unified dictionary still loads bytes and a MIME type.
- `UIImage` registered directly is served as `image/png` with bytes matching `pngData()`.
- Existing 9 tests continue to pass with the new value type.

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Generalises `SuperwallOptions.localResources` from `[String: URL]` to `[String: AssetResource]`, adding `UIImage` conformance so customers can register asset-catalog Image Sets without needing a file URL. The ObjC bridge, PNG caching, debug preview, and tests are all cleanly handled, and all issues raised in previous review rounds appear to have been addressed in this iteration.

<h3>Confidence Score: 5/5</h3>

PR is safe to merge; no P0/P1 issues found in the current implementation.

The change is well-scoped and backwards-compatible. URL call sites continue to work unchanged, the ObjC bridge uses the established @available(swift, obsoleted:) pattern correctly, the manual encode(to:) already excludes localResources so Encodable synthesis is not a concern, NSCache is thread-safe and UIImage.pngData() is documented as thread-safe, and both new code paths have test coverage. All issues flagged in prior review threads have been resolved in this iteration.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Config/Options/AssetResource.swift | New protocol defining the AssetResource type with URL and UIImage conformances; clean and minimal. |
| Sources/SuperwallKit/Paywall/View Controller/Web View/LocalFileSchemeHandler.swift | Adds UIImage dispatch with per-instance NSCache; thread-safe and handles pngData nil guard correctly. |
| Sources/SuperwallKit/Config/Options/SuperwallOptions.swift | Widens localResources to [String: AssetResource] with a correct @available(swift, obsoleted:) ObjC bridge; manual encode(to:) already omits the property, avoiding Encodable synthesis issues. |
| Sources/SuperwallKit/Debug/SWLocalResourcesViewController.swift | Debug view updated to dispatch on resource type; UIImage case renders the image directly, avoiding the prior NSDataAsset Image-Set gap. |
| Tests/SuperwallKitTests/Paywall/View Controller/Web View/LocalFileSchemeHandlerTests.swift | Two new tests cover URL conformance and UIImage round-trip; existing suite remains intact. |
| Sources/SuperwallKit/Config/ConfigLogic.swift | Minor trailing-closure style cleanup; semantically identical. |
| CHANGELOG.md | Enhancement entry added; accurate description of the new UIImage support. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant SuperwallOptions
    participant WKWebView
    participant LocalFileSchemeHandler
    participant NSCache

    App->>SuperwallOptions: localResources["logo"] = UIImage(named:)
    App->>SuperwallOptions: localResources["hero"] = Bundle.main.url(...)

    WKWebView->>LocalFileSchemeHandler: webView(_:start:) [swlocal://logo]
    LocalFileSchemeHandler->>SuperwallOptions: options.localResources["logo"]
    SuperwallOptions-->>LocalFileSchemeHandler: UIImage instance
    LocalFileSchemeHandler->>NSCache: object(forKey: image)
    alt Cache hit
        NSCache-->>LocalFileSchemeHandler: NSData (PNG bytes)
    else Cache miss
        LocalFileSchemeHandler->>LocalFileSchemeHandler: image.pngData()
        LocalFileSchemeHandler->>NSCache: setObject(data, forKey: image)
    end
    LocalFileSchemeHandler-->>WKWebView: URLResponse + PNG data (image/png)

    WKWebView->>LocalFileSchemeHandler: webView(_:start:) [swlocal://hero]
    LocalFileSchemeHandler->>SuperwallOptions: options.localResources["hero"]
    SuperwallOptions-->>LocalFileSchemeHandler: URL (file path)
    LocalFileSchemeHandler->>LocalFileSchemeHandler: Data(contentsOf: url)
    LocalFileSchemeHandler-->>WKWebView: URLResponse + file data (MIME from extension)
```

<sub>Reviews (6): Last reviewed commit: ["Promote image PNG cache to static for cr..."](https://github.com/superwall/superwall-ios/commit/64a3a6e0cbdf7170c940d9ded5c14b24fc86dc39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29616179)</sub>

<!-- /greptile_comment -->