### PR TITLE
Switch SwiftPM Superscript dep to superscript-ios-next

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Package Management
 - Swift Package Manager: Primary dependency management via `Package.swift`
 - CocoaPods: Also supported via `SuperwallKit.podspec`
-- Dependencies: `Superscript-iOS` at exact version 1.0.4
+- Dependencies: `superscript-ios-next` at exact version 1.0.14 (slim binary-target distribution; replaces the legacy `Superscript-iOS` repo whose committed xcframework bloated clones)
 
 ## Architecture Overview
 

--- a/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "Superscript",
-        "repositoryURL": "https://github.com/superwall/Superscript-iOS",
+        "repositoryURL": "https://github.com/superwall/superscript-ios-next",
         "state": {
           "branch": null,
-          "revision": "711866edcb62dbd237c24ed3e5fa39fad0db639f",
-          "version": "1.0.13"
+          "revision": "abb2c8c96e958aabe11a84df67860ad7bbef3b68",
+          "version": "1.0.14"
         }
       }
     ]

--- a/Examples/Basic/Basic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Basic/Basic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Superscript",
-        "repositoryURL": "https://github.com/superwall/Superscript-iOS",
+        "repositoryURL": "https://github.com/superwall/superscript-ios-next",
         "state": {
           "branch": null,
-          "revision": "711866edcb62dbd237c24ed3e5fa39fad0db639f",
-          "version": "1.0.13"
+          "revision": "abb2c8c96e958aabe11a84df67860ad7bbef3b68",
+          "version": "1.0.14"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Superscript",
-        "repositoryURL": "https://github.com/superwall/Superscript-iOS",
+        "repositoryURL": "https://github.com/superwall/superscript-ios-next",
         "state": {
           "branch": null,
-          "revision": "711866edcb62dbd237c24ed3e5fa39fad0db639f",
-          "version": "1.0.13"
+          "revision": "abb2c8c96e958aabe11a84df67860ad7bbef3b68",
+          "version": "1.0.14"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/superwall/Superscript-iOS", .exact("1.0.13"))
+    .package(url: "https://github.com/superwall/superscript-ios-next", .exact("1.0.14"))
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,7 +27,7 @@ let package = Package(
     .target(
       name: "SuperwallKit",
       dependencies: [
-        .product(name: "Superscript", package: "Superscript-iOS")
+        .product(name: "Superscript", package: "superscript-ios-next")
       ],
       exclude: ["Resources/BundleHelper.swift"],
       resources: [

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -3149,7 +3149,7 @@
 			);
 			mainGroup = 5CE8CEF97A892FFF3D0D8F06;
 			packageReferences = (
-				8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "Superscript-iOS" */,
+				8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -4019,12 +4019,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "Superscript-iOS" */ = {
+		8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/superwall/Superscript-iOS";
+			repositoryURL = "https://github.com/superwall/superscript-ios-next";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.13;
+				version = 1.0.14;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -4032,7 +4032,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		721C720FA8360B9851DE843D /* Superscript */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "Superscript-iOS" */;
+			package = 8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */;
 			productName = Superscript;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,12 @@
   "originHash" : "db362fdf36eaf1c479870b40c7a6c2e2165345c7210ebe36257ee38523125878",
   "pins" : [
     {
-      "identity" : "superscript-ios",
+      "identity" : "superscript-ios-next",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/superwall/Superscript-iOS",
+      "location" : "https://github.com/superwall/superscript-ios-next",
       "state" : {
-        "revision" : "711866edcb62dbd237c24ed3e5fa39fad0db639f",
-        "version" : "1.0.13"
+        "revision" : "abb2c8c96e958aabe11a84df67860ad7bbef3b68",
+        "version" : "1.0.14"
       }
     }
   ],

--- a/project.yml
+++ b/project.yml
@@ -4,8 +4,8 @@ options:
 
 packages:
   Superscript:
-    url: https://github.com/superwall/Superscript-iOS
-    exactVersion: "1.0.13"
+    url: https://github.com/superwall/superscript-ios-next
+    exactVersion: "1.0.14"
 
 targets:
   SuperwallKit:


### PR DESCRIPTION
## Summary

- Switches the SwiftPM `Superscript` dependency from [`superwall/Superscript-iOS`](https://github.com/superwall/Superscript-iOS) to the new slim repo [`superwall/superscript-ios-next`](https://github.com/superwall/superscript-ios-next), pinned at `1.0.14`.
- Module name (`Superscript`) is unchanged, so no source edits required.

## Why

`Superscript-iOS` has been committing the ~250 MB `libcel.xcframework` into git on every release for over 20 versions. Its `.git` is ~1.2 GB and SwiftPM cannot do shallow clones, so every fresh `swift package resolve` of SuperwallKit pays for the full clone — minutes on slow connections, painful on CI.

`superscript-ios-next` distributes the framework as a GitHub Release asset and uses SwiftPM's `binaryTarget(url:checksum:)`. The repo itself is ~60 KB. I measured a fresh consumer resolve and the git-side work completes in **~2 seconds**; the binary download is then cached at `~/Library/Caches/org.swift.swiftpm`.

## What's NOT in this PR

CocoaPods is intentionally untouched. `SuperwallKit.podspec` still depends on `Superscript` 1.0.13 from CocoaPods Trunk. The pod is published by the legacy repo's pipeline, and `superscript-ios-next` does not yet have its `COCOAPODS_TRUNK_TOKEN` configured. Once that's set up and a release is published from the new repo, we can bump the podspec dep in a follow-up PR. Pod consumers are unaffected by this change.

## Files touched

| File | Change |
|---|---|
| `Package.swift` | `package(url:)` and `product(name:package:)` updated |
| `Package.resolved` | regenerated by `swift package resolve` |
| `project.yml` | XcodeGen `packages.Superscript.url` + `exactVersion` |
| `SuperwallKit.xcodeproj/project.pbxproj` | `XCRemoteSwiftPackageReference` URL + version |
| `SuperwallKit.xcodeproj/.../Package.resolved` | re-pinned |
| `Examples/Basic/.../Package.resolved` | re-pinned |
| `Examples/Advanced/.../Package.resolved` | re-pinned |
| `CLAUDE.md` | dependency note refreshed |

## Test plan

- [ ] `swift package resolve` succeeds (verified locally — git ops finish in ~2s vs. minutes against the legacy repo)
- [ ] `swift build` for SuperwallKit succeeds against the new dep
- [ ] CI passes
- [ ] Open `SuperwallKit.xcodeproj` in Xcode, confirm package re-resolves cleanly (Xcode will refresh the `originHash` in the workspace `Package.resolved` automatically — minor follow-up diff expected)
- [ ] Build & run `Examples/Basic` and `Examples/Advanced` end-to-end
- [ ] Smoke-test audience-filter evaluation (the `Superscript` consumers in `CELEvaluator.swift` and `EvaluationContext.swift`) — module API surface is identical, but the underlying xcframework comes via a different transport now

## Related

- New repo: <https://github.com/superwall/superscript-ios-next>
- First release: <https://github.com/superwall/superscript-ios-next/releases/tag/1.0.14>
- Rust-side dispatch fan-out PR: <https://github.com/superwall/superscript/pull/47>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the SwiftPM `Superscript` dependency from `superwall/Superscript-iOS` (1.0.13) to `superwall/superscript-ios-next` (1.0.14), a slim repo that distributes `libcel.xcframework` via a GitHub Release binary target instead of committing it to git. All eight affected files (`Package.swift`, `project.yml`, `project.pbxproj`, and five `Package.resolved` files) are updated consistently to the same URL, version, and revision (`abb2c8c9`); the public module name `Superscript` is unchanged so no source edits are needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a dependency source/version update with no source code changes and full consistency across all resolved files.

All Package.resolved files agree on the new URL, version 1.0.14, and commit hash `abb2c8c9`. The public module API is unchanged. CocoaPods is intentionally left at the previous version with a clear follow-up plan. No logic changes, no source edits, no migration risks.

No files require special attention. The `originHash` in `SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` is expected to regenerate when Xcode next opens the project, as noted in the PR test plan.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Package.swift | Dependency URL and package name updated from `Superscript-iOS` 1.0.13 to `superscript-ios-next` 1.0.14; module product name `Superscript` unchanged so no import churn. |
| Package.resolved | Re-pinned to `superscript-ios-next` 1.0.14 at commit `abb2c8c9`; consistent with all other resolved files in the PR. |
| SuperwallKit.xcodeproj/project.pbxproj | `XCRemoteSwiftPackageReference` URL and version updated to `superscript-ios-next` 1.0.14; PBXPROJ object IDs preserved, product dependency name `Superscript` unchanged. |
| SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved | v2-format resolved file re-pinned to `superscript-ios-next` 1.0.14; `originHash` may be regenerated by Xcode on next open (noted in PR test plan). |
| project.yml | XcodeGen `packages.Superscript` URL and `exactVersion` updated to `superscript-ios-next` 1.0.14; consistent with `Package.swift`. |
| CLAUDE.md | Dependency note updated; also incidentally fixes a pre-existing stale version (CLAUDE.md said 1.0.4 but Package.swift had 1.0.13). |
| Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved | Re-pinned to `superscript-ios-next` 1.0.14 at the same revision as the root resolved file. |
| Examples/Basic/Basic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved | Re-pinned to `superscript-ios-next` 1.0.14 at the same revision as the root resolved file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuperwallKit consumers] --> B[Package.swift / project.yml]
    B -->|SwiftPM resolves| C[superscript-ios-next @ 1.0.14\ngithub.com/superwall/superscript-ios-next]
    C -->|binaryTarget download\ncached in ~/Library/Caches| D[libcel.xcframework]
    D --> E[Superscript module\nused by CELEvaluator.swift\nand EvaluationContext.swift]
    B2[SuperwallKit.podspec] -->|CocoaPods — unchanged| F[Superscript 1.0.13 on CocoaPods Trunk\nlegacy Superscript-iOS repo]
    F --> G[libcel.xcframework\ncommitted to git — follow-up PR planned]
    style C fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
```

<sub>Reviews (1): Last reviewed commit: ["Switch SwiftPM Superscript dependency to..."](https://github.com/superwall/superwall-ios/commit/639cfd8f5235a51aa7468136638f457c03cf1c2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30779399)</sub>

<!-- /greptile_comment -->