### PR TITLE
Improve Apple Search Ads attribution capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Improves Apple Search Ads attribution capture rate. The SDK now retries the AdServices token fetch and backend post with backoff when transient errors occur (e.g. when Apple's attribution endpoint isn't ready yet right after install), and only marks the token as successfully posted after the backend confirms. Previously a single transient failure could permanently lose attribution for that install.
+- Apple Search Ads attribution is now install-scoped: once the campaign data is fetched for a device, it's cached and re-applied to any new user identity on `reset()`/`identify()`. Previously each new user would trigger a fresh fetch, which silently failed past Apple's 24h post-install window. Existing users are migrated transparently on first launch.
 - Filters out the all-zeros IDFA sentinel (returned when App Tracking Transparency is denied) so it no longer pollutes the `idfa` attribute on attribution payloads.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 4.15.2
 
+### Enhancements
+
+- Improves Apple Search Ads attribution capture rate. The SDK now retries the AdServices token fetch and backend post with backoff when transient errors occur (e.g. when Apple's attribution endpoint isn't ready yet right after install), and only marks the token as successfully posted after the backend confirms. Previously a single transient failure could permanently lose attribution for that install.
+- Filters out the all-zeros IDFA sentinel (returned when App Tracking Transparency is denied) so it no longer pollutes the `idfa` attribute on attribution payloads.
+
 ### Fixes
 
 - Changes the Superscript spm package repo source to a new lightweight repo meaning that the download of the package is way faster.
+- Fixes a race where two near-simultaneous triggers (config arrival + app foreground) could both start an AdServices token fetch.
 
 ## 4.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,12 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Enhancements
 
-- Improves Apple Search Ads attribution capture rate. The SDK now retries the AdServices token fetch and backend post with backoff when transient errors occur (e.g. when Apple's attribution endpoint isn't ready yet right after install), and only marks the token as successfully posted after the backend confirms. Previously a single transient failure could permanently lose attribution for that install.
-- Apple Search Ads attribution is now install-scoped: once the campaign data is fetched for a device, it's cached and re-applied to any new user identity on `reset()`/`identify()`. Previously each new user would trigger a fresh fetch, which silently failed past Apple's 24h post-install window. Existing users are migrated transparently on first launch.
+- Improves Apple Search Ads attribution capture rate.
 - Filters out the all-zeros IDFA sentinel (returned when App Tracking Transparency is denied) so it no longer pollutes the `idfa` attribute on attribution payloads.
 
 ### Fixes
 
 - Changes the Superscript spm package repo source to a new lightweight repo meaning that the download of the package is way faster.
-- Fixes a race where two near-simultaneous triggers (config arrival + app foreground) could both start an AdServices token fetch.
 
 ## 4.15.1
 

--- a/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "a06accc1543fcedc3094d4b5b9a40b84e2213e8e",
-          "version": "5.69.0"
+          "revision": "6b95744e70f1edc43f89f2b522b0832ddfdd41a1",
+          "version": "5.73.0"
         }
       },
       {

--- a/Sources/SuperwallKit/Analytics/Attribution/AdServicesAttributionAttempts.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AdServicesAttributionAttempts.swift
@@ -1,0 +1,16 @@
+//
+//  AdServicesAttributionAttempts.swift
+//  SuperwallKit
+//
+
+import Foundation
+
+struct AdServicesAttributionAttempts: Codable, Equatable {
+  /// Total attempts that have completed (either at Apple's SDK call or the
+  /// backend post).
+  var count: Int
+  /// When we first tried for this install. Used to bound how long we keep
+  /// retrying — Apple's attribution data is only useful within ~24h of install.
+  var firstAttemptDate: Date
+  var lastAttemptDate: Date
+}

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
@@ -43,11 +43,20 @@ final class AttributionFetcher {
         return nil
       }
 
+      // When ATT hasn't been authorized iOS returns the all-zeros UUID
+      // sentinel. Don't pass that through as an IDFA — it pollutes attribution
+      // payloads with junk that downstream MMPs treat as a real id.
+      if identifierValue == Self.zeroAdvertisingIdentifier {
+        return nil
+      }
+
       return identifierValue.uuidString
     }
     #endif
     return nil
   }
+
+  private static let zeroAdvertisingIdentifier = UUID(uuidString: "00000000-0000-0000-0000-000000000000")
 
   // should match OS availability in https://developer.apple.com/documentation/ad_services
   @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
@@ -58,6 +58,23 @@ final class AttributionFetcher {
 
   private static let zeroAdvertisingIdentifier = UUID(uuidString: "00000000-0000-0000-0000-000000000000")
 
+  /// Whether this build/environment can ever produce an AdServices token.
+  /// `false` on builds that didn't link AdServices.framework and on debug
+  /// simulator runs without `SUPERWALL_MOCK_AD_SERVICES_TOKEN`. Lets the
+  /// poster short-circuit before entering its 23s backoff schedule in
+  /// development.
+  var canProduceAdServicesToken: Bool {
+    #if !canImport(AdServices)
+    return false
+    #else
+    #if targetEnvironment(simulator) && DEBUG
+    return ProcessInfo.processInfo.environment["SUPERWALL_MOCK_AD_SERVICES_TOKEN"] != nil
+    #else
+    return true
+    #endif
+    #endif
+  }
+
   // should match OS availability in https://developer.apple.com/documentation/ad_services
   @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
   var adServicesToken: String? {

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -249,27 +249,13 @@ final class AttributionPoster {
     do {
       // CustomURLSession already wraps the request in Task.retrying (3
       // attempts × 5s for the AdServices endpoint, see Endpoint.swift), so
-      // we don't need our own outer backoff here. Persistent failures fall
-      // through to recordFailedAttempt and the next launch picks up via the
-      // cross-launch attempt budget.
+      // we don't need our own outer backoff here. Backend error responses
+      // come back as non-2xx and are thrown by Task.retrying — they end up
+      // in the catch below and bump the cross-launch attempt budget.
       let response = try await network.sendToken(token)
       if Task.isCancelled {
         return
       }
-      // A non-nil `error` means the backend (or Apple, via the backend)
-      // couldn't resolve attribution for this token. Treat as a retryable
-      // failure rather than burying it under the success sentinel.
-      if let backendError = response.error {
-        throw NSError(
-          domain: "com.superwall.attributionposter",
-          code: -1,
-          userInfo: [NSLocalizedDescriptionKey: backendError]
-        )
-      }
-      // `eligible == false` is a definitive answer from Apple ("this user
-      // wasn't from Search Ads") — fall through to the success path so we
-      // save the sentinel and stop retrying. Same outcome as a non-empty
-      // attribution; only the user-attribute write is skipped.
       let attribution = convertJSONToDictionary(attribution: response.attribution)
       storage.save(token, forType: AdServicesTokenStorage.self)
       storage.delete(AdServicesAttributionAttemptsStorage.self)

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -346,15 +346,25 @@ private enum PosterError: Error, Equatable {
 }
 
 extension AttributionPoster {
+  /// AdServices.framework error code for `platformNotSupported`. From
+  /// Apple's `AAAttribution.h`:
+  ///
+  ///     AAAttributionErrorCodeNetworkError = 1,         // transient
+  ///     AAAttributionErrorCodeInternalError = 2,        // transient
+  ///     AAAttributionErrorCodePlatformNotSupported = 3, // permanent
+  ///
+  /// `NS_ERROR_ENUM` doesn't reliably import as a Swift symbol across SDK
+  /// versions, so we match on the raw code with the constant clearly named.
+  private static let platformNotSupportedCode = 3
+
   static func isPermanentTokenError(_ error: Error) -> Bool {
-    // AAAttributionErrorCode is not consistently exposed as a typed enum
-    // across SDK versions, so match on the NSError domain/code numerically.
-    // Codes 2 (.platformNotSupported) and 3 (.attributionUnsupported) are
-    // permanent on this device; the rest are treated as transient.
+    // Only `platformNotSupported` is permanent — this OS/app config will
+    // never produce a token. `networkError` and `internalError` are both
+    // transient and should keep retrying within the per-install budget.
     let nsError = error as NSError
     guard nsError.domain == "AAAttributionErrorDomain" else {
       return false
     }
-    return nsError.code == 2 || nsError.code == 3
+    return nsError.code == platformNotSupportedCode
   }
 }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -83,7 +83,10 @@ final class AttributionPoster {
       .sink(
         receiveCompletion: { _ in },
         receiveValue: { [weak self] _ in
-          Task {
+          // Match applicationWillEnterForeground's priority: default-priority
+          // tasks can be deferred under load, and attribution is bounded by
+          // Apple's 24h install window.
+          Task(priority: .utility) {
             await self?.getAdServicesTokenIfNeeded()
           }
         }
@@ -360,7 +363,7 @@ extension AttributionPoster {
   /// versions, so we match on the raw code with the constant clearly named.
   private static let platformNotSupportedCode = 3
 
-  static func isPermanentTokenError(_ error: Error) -> Bool {
+  private static func isPermanentTokenError(_ error: Error) -> Bool {
     // Only `platformNotSupported` is permanent — this OS/app config will
     // never produce a token. `networkError` and `internalError` are both
     // transient and should keep retrying within the per-install budget.

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -57,8 +57,6 @@ final class AttributionPoster {
     self.configManager = configManager
     self.attributionFetcher = attributionFetcher
 
-    Self.migrateLegacyTokenSentinelIfNeeded(storage: storage)
-
     if #available(iOS 14.3, *) {
       listenToConfig()
     }
@@ -109,23 +107,6 @@ final class AttributionPoster {
       }
     }
     #endif
-  }
-
-  /// Moves the AdServices token sentinel from the legacy user-specific
-  /// location to the new app-specific location on first launch after upgrade.
-  /// Without this, existing users would look "never attributed" and we'd
-  /// hammer Apple with retries even though we already finished for them.
-  private static func migrateLegacyTokenSentinelIfNeeded(storage: Storage) {
-    if storage.get(AdServicesTokenStorage.self) != nil {
-      return
-    }
-    guard let legacyToken = storage.get(LegacyUserScopedAdServicesTokenStorage.self) else {
-      return
-    }
-    storage.save(legacyToken, forType: AdServicesTokenStorage.self)
-    // We don't delete the legacy file — its on-disk key collides with the
-    // new one in the memCache layer, so a delete would evict the entry we
-    // just wrote. The orphan file is ~50 bytes and harmless.
   }
 
   /// Re-applies the cached ASA attribution dict to the current user's

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -7,34 +7,37 @@
 
 import Foundation
 import Combine
+#if canImport(AdServices)
+import AdServices
+#endif
 
 final class AttributionPoster {
+  /// Hard cap on attempts across launches. Apple's attribution endpoint can be
+  /// unhealthy for short periods around install, so we want enough retries to
+  /// survive that, but not so many that we keep hammering it for users who
+  /// will never have attribution data.
+  private static let maxAttempts = 8
+
+  /// Maximum window from the first attempt during which we'll keep retrying.
+  /// Apple's attribution data is only useful within ~24h of install, so 48h
+  /// gives generous slack for the very-first launch happening late in the
+  /// window without continuing indefinitely.
+  private static let maxRetryWindow: TimeInterval = 48 * 60 * 60
+
+  /// In-session retry plan for transient errors at the SDK or network layer.
+  /// Backoff grows so a single bad-network pocket doesn't burn through the
+  /// per-install attempt budget.
+  private static let inSessionBackoff: [TimeInterval] = [2, 6, 15]
+
+  private let stateQueue = DispatchQueue(label: "com.superwall.attributionposter.state")
   private var isCollecting = false
+  private var currentTask: Task<Void, Never>?
 
   private unowned let storage: Storage
   private unowned let network: Network
   private unowned let configManager: ConfigManager
   private unowned let attributionFetcher: AttributionFetcher
   private var cancellables: [AnyCancellable] = []
-
-  private var adServicesTokenToPostIfNeeded: String? {
-    get async throws {
-      #if os(tvOS) || os(watchOS)
-      return nil
-      #else
-      guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
-        return nil
-      }
-
-      guard storage.get(AdServicesTokenStorage.self) == nil else {
-        return nil
-      }
-
-      await Superwall.shared.track(InternalSuperwallEvent.AdServicesTokenRetrieval(state: .start))
-      return try await attributionFetcher.adServicesToken
-      #endif
-    }
-  }
 
   init(
     storage: Storage,
@@ -59,17 +62,17 @@ final class AttributionPoster {
     )
   }
 
-
   @available(iOS 14.3, *)
   private func listenToConfig() {
+    // Don't use `.first` here: if the dashboard flips Apple Search Ads from
+    // disabled to enabled mid-session we still want to react.
     configManager.configState
       .compactMap { $0.getConfig() }
-      .first { config in
-        config.attribution?.appleSearchAds?.enabled == true
-      }
+      .filter { $0.attribution?.appleSearchAds?.enabled == true }
+      .removeDuplicates { _, _ in true } // only trigger once per process
       .sink(
         receiveCompletion: { _ in },
-        receiveValue: { _ in
+        receiveValue: { [weak self] _ in
           Task { [weak self] in
             await self?.getAdServicesTokenIfNeeded()
           }
@@ -85,7 +88,10 @@ final class AttributionPoster {
       return
     }
 
-    Task(priority: .background) {
+    // .utility rather than .background — background-priority tasks can be
+    // deferred indefinitely under load, but the attribution token is only
+    // useful within ~24h of install.
+    Task(priority: .utility) {
       if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
         await getAdServicesTokenIfNeeded()
       }
@@ -93,38 +99,201 @@ final class AttributionPoster {
     #endif
   }
 
+  /// Cancel any in-flight attempt. Used during reset so we don't race a
+  /// completing post against the new user's state.
+  func cancelInFlight() {
+    stateQueue.sync {
+      currentTask?.cancel()
+      currentTask = nil
+      isCollecting = false
+    }
+  }
+
   // Should match OS availability in https://developer.apple.com/documentation/ad_services
   @available(iOS 14.3, tvOS 14.3, watchOS 6.2, macOS 11.1, macCatalyst 14.3, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   func getAdServicesTokenIfNeeded() async {
-    if isCollecting {
+    // Single-flight: only one collection at a time. Synchronous check on the
+    // state queue avoids the TOCTOU race in the previous implementation.
+    let shouldStart: Bool = stateQueue.sync {
+      if isCollecting {
+        return false
+      }
+      isCollecting = true
+      return true
+    }
+    guard shouldStart else {
       return
     }
     defer {
-      isCollecting = false
+      stateQueue.sync {
+        isCollecting = false
+        currentTask = nil
+      }
     }
+
+    // Already successfully posted for this install.
+    if storage.get(AdServicesTokenStorage.self) != nil {
+      return
+    }
+
+    guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
+      return
+    }
+
+    let attempts = storage.get(AdServicesAttributionAttemptsStorage.self)
+    if let attempts = attempts {
+      if attempts.count >= Self.maxAttempts {
+        return
+      }
+      if Date().timeIntervalSince(attempts.firstAttemptDate) > Self.maxRetryWindow {
+        return
+      }
+    }
+
+    await Superwall.shared.track(InternalSuperwallEvent.AdServicesTokenRetrieval(state: .start))
+
+    let task = Task<Void, Never> { [weak self] in
+      await self?.runAttempt(existingAttempts: attempts)
+    }
+    stateQueue.sync {
+      currentTask = task
+    }
+    await task.value
+  }
+
+  @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+  private func runAttempt(existingAttempts: AdServicesAttributionAttempts?) async {
+    let token: String
     do {
-      isCollecting = true
-      guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
-        return
-      }
-      guard let token = try await adServicesTokenToPostIfNeeded else {
-        return
-      }
-
-      storage.save(token, forType: AdServicesTokenStorage.self)
-
-      await Superwall.shared.track(
-        InternalSuperwallEvent.AdServicesTokenRetrieval(state: .complete(token))
-      )
-
-      let data = await network.sendToken(token)
-      Superwall.shared.setUserAttributes(data)
-    } catch {
+      token = try await fetchTokenWithBackoff()
+    } catch let error as PosterError where error == .permanentlyUnsupported {
+      // Don't burn the attempt budget on a device that will never have a token.
       await Superwall.shared.track(
         InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(error))
       )
+      return
+    } catch {
+      recordFailedAttempt(existing: existingAttempts)
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(error))
+      )
+      return
     }
+
+    if Task.isCancelled {
+      return
+    }
+
+    await Superwall.shared.track(
+      InternalSuperwallEvent.AdServicesTokenRetrieval(state: .complete(token))
+    )
+
+    do {
+      let response = try await postTokenWithBackoff(token: token)
+      if Task.isCancelled {
+        return
+      }
+      // The backend can explicitly tell us this user wasn't from Search Ads —
+      // treat that the same as success so we stop retrying.
+      let attribution = convertJSONToDictionary(attribution: response.attribution)
+      storage.save(token, forType: AdServicesTokenStorage.self)
+      storage.delete(AdServicesAttributionAttemptsStorage.self)
+
+      if !attribution.isEmpty {
+        Superwall.shared.setUserAttributes(attribution)
+      }
+    } catch {
+      recordFailedAttempt(existing: existingAttempts)
+    }
+  }
+
+  /// Retrieves the token from Apple's AdServices framework, retrying transient
+  /// errors a few times in-session. `AAAttribution.attributionToken()` can
+  /// throw `networkError` very early in the app's lifecycle even though the
+  /// next call milliseconds later would succeed.
+  @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+  private func fetchTokenWithBackoff() async throws -> String {
+    var lastError: Error?
+    for delay in [0.0] + Self.inSessionBackoff {
+      if delay > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+      }
+      if Task.isCancelled {
+        throw CancellationError()
+      }
+      do {
+        if let token = try await attributionFetcher.adServicesToken {
+          return token
+        }
+        throw PosterError.tokenUnavailable
+      } catch {
+        if Self.isPermanentTokenError(error) {
+          throw PosterError.permanentlyUnsupported
+        }
+        lastError = error
+      }
+    }
+    throw lastError ?? PosterError.tokenUnavailable
+  }
+
+  /// Sends the token to our backend, retrying transient failures with
+  /// backoff. `CustomURLSession` already retries the HTTP call internally —
+  /// these retries cover the case where every internal retry fails but a
+  /// short pause yields a different result (e.g. Apple's attribution endpoint
+  /// catching up post-install).
+  private func postTokenWithBackoff(token: String) async throws -> AdServicesResponse {
+    var lastError: Error?
+    for delay in [0.0] + Self.inSessionBackoff {
+      if delay > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+      }
+      if Task.isCancelled {
+        throw CancellationError()
+      }
+      do {
+        return try await network.sendToken(token)
+      } catch {
+        lastError = error
+      }
+    }
+    throw lastError ?? NetworkError.unknown
+  }
+
+  private func recordFailedAttempt(existing: AdServicesAttributionAttempts?) {
+    let now = Date()
+    let updated: AdServicesAttributionAttempts
+    if let existing = existing {
+      updated = AdServicesAttributionAttempts(
+        count: existing.count + 1,
+        firstAttemptDate: existing.firstAttemptDate,
+        lastAttemptDate: now
+      )
+    } else {
+      updated = AdServicesAttributionAttempts(
+        count: 1,
+        firstAttemptDate: now,
+        lastAttemptDate: now
+      )
+    }
+    storage.save(updated, forType: AdServicesAttributionAttemptsStorage.self)
+  }
+
+  private static func isPermanentTokenError(_ error: Error) -> Bool {
+    // AAAttributionErrorCode is not consistently exposed as a typed enum
+    // across SDK versions, so match on the NSError domain/code numerically.
+    // Codes 2 (.platformNotSupported) and 3 (.attributionUnsupported) are
+    // permanent on this device; the rest are treated as transient.
+    let nsError = error as NSError
+    guard nsError.domain == "AAAttributionErrorDomain" else {
+      return false
+    }
+    return nsError.code == 2 || nsError.code == 3
+  }
+
+  private enum PosterError: Error, Equatable {
+    case tokenUnavailable
+    case permanentlyUnsupported
   }
 }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -183,6 +183,12 @@ final class AttributionPoster {
     let token: String
     do {
       token = try await fetchTokenWithBackoff()
+    } catch is CancellationError {
+      // Cancellation means `cancelInFlight` (typically via reset) asked us to
+      // abandon — not a real failure. Don't bookkeep an attempt, especially
+      // because storage may have just been wiped and `existingAttempts` is
+      // stale; writing it would inflate the new user's attempt count.
+      return
     } catch let error as PosterError where error == .permanentlyUnsupported {
       // Don't burn the attempt budget on a device that will never have a token.
       await Superwall.shared.track(
@@ -219,6 +225,8 @@ final class AttributionPoster {
       if !attribution.isEmpty {
         Superwall.shared.setUserAttributes(attribution)
       }
+    } catch is CancellationError {
+      return
     } catch {
       recordFailedAttempt(existing: existingAttempts)
     }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -83,7 +83,7 @@ final class AttributionPoster {
       .sink(
         receiveCompletion: { _ in },
         receiveValue: { [weak self] _ in
-          Task { [weak self] in
+          Task {
             await self?.getAdServicesTokenIfNeeded()
           }
         }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -152,40 +152,62 @@ final class AttributionPoster {
       }
     }
 
-    // Already successfully posted for this install.
-    if storage.get(AdServicesTokenStorage.self) != nil {
-      return
-    }
-
-    // This device permanently can't provide an attribution token (missing
-    // entitlement, unsupported platform). Stop retrying.
-    if storage.get(AdServicesAttributionUnsupportedStorage.self) == true {
-      return
-    }
-
-    guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
-      return
-    }
-
     let attempts = storage.get(AdServicesAttributionAttemptsStorage.self)
-    if let attempts = attempts {
-      if attempts.count >= Self.maxAttempts {
-        return
-      }
-      if Date().timeIntervalSince(attempts.firstAttemptDate) > Self.maxRetryWindow {
-        return
-      }
+    guard canStartAttempt(currentAttempts: attempts) else {
+      return
     }
 
     await Superwall.shared.track(InternalSuperwallEvent.AdServicesTokenRetrieval(state: .start))
 
-    let task = Task<Void, Never> { [weak self] in
-      await self?.runAttempt(existingAttempts: attempts)
-    }
-    stateQueue.sync {
+    // Re-check ownership, then create and store the task atomically inside
+    // the queue. `cancelInFlight()` may have fired while we were suspended
+    // on the track call above (before `currentTask` was ever stored), in
+    // which case our pre-reset `existingAttempts` snapshot is now stale and
+    // running runAttempt would clobber the new user's freshly reset storage.
+    // Doing the create+store inside the same sync block also prevents
+    // cancelInFlight from running between Task creation and storage, which
+    // would otherwise leave the task uncancellable from the outside.
+    let task: Task<Void, Never>? = stateQueue.sync {
+      guard ownerGeneration == myGeneration else {
+        return nil
+      }
+      let task = Task<Void, Never> { [weak self] in
+        await self?.runAttempt(existingAttempts: attempts)
+      }
       currentTask = task
+      return task
+    }
+    guard let task = task else {
+      return
     }
     await task.value
+  }
+
+  /// Storage and config guards that decide whether it's worth starting a
+  /// fresh attempt. Pulled out of `getAdServicesTokenIfNeeded` so the main
+  /// flow stays under the cyclomatic-complexity budget.
+  private func canStartAttempt(currentAttempts: AdServicesAttributionAttempts?) -> Bool {
+    // Already successfully posted for this install.
+    if storage.get(AdServicesTokenStorage.self) != nil {
+      return false
+    }
+    // This device permanently can't provide an attribution token (missing
+    // entitlement, unsupported platform). Stop retrying.
+    if storage.get(AdServicesAttributionUnsupportedStorage.self) == true {
+      return false
+    }
+    guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
+      return false
+    }
+    if let attempts = currentAttempts {
+      if attempts.count >= Self.maxAttempts {
+        return false
+      }
+      if Date().timeIntervalSince(attempts.firstAttemptDate) > Self.maxRetryWindow {
+        return false
+      }
+    }
+    return true
   }
 
   @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -32,6 +32,10 @@ final class AttributionPoster {
   private let stateQueue = DispatchQueue(label: "com.superwall.attributionposter.state")
   private var isCollecting = false
   private var currentTask: Task<Void, Never>?
+  /// Monotonic generation stamped onto each outer call that claims the slot.
+  /// `cancelInFlight` bumps this so a late-completing call's `defer` won't
+  /// clobber the state belonging to a newly started call.
+  private var ownerGeneration: UInt64 = 0
 
   private unowned let storage: Storage
   private unowned let network: Network
@@ -106,6 +110,10 @@ final class AttributionPoster {
       currentTask?.cancel()
       currentTask = nil
       isCollecting = false
+      // Invalidate the in-flight outer call's ownership so its `defer`
+      // becomes a no-op once it unblocks from `await task.value` — otherwise
+      // it would clobber state belonging to a newly started call.
+      ownerGeneration &+= 1
     }
   }
 
@@ -116,18 +124,25 @@ final class AttributionPoster {
   func getAdServicesTokenIfNeeded() async {
     // Single-flight: only one collection at a time. Synchronous check on the
     // state queue avoids the TOCTOU race in the previous implementation.
-    let shouldStart: Bool = stateQueue.sync {
+    // The generation stamp lets the cleanup `defer` detect whether we still
+    // own the slot when we unblock — `cancelInFlight` may have released it
+    // and a new call may have already claimed it.
+    let myGeneration: UInt64? = stateQueue.sync {
       if isCollecting {
-        return false
+        return nil
       }
       isCollecting = true
-      return true
+      ownerGeneration &+= 1
+      return ownerGeneration
     }
-    guard shouldStart else {
+    guard let myGeneration = myGeneration else {
       return
     }
     defer {
       stateQueue.sync {
+        guard ownerGeneration == myGeneration else {
+          return
+        }
         isCollecting = false
         currentTask = nil
       }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -177,16 +177,12 @@ final class AttributionPoster {
       return
     }
 
-    await Superwall.shared.track(InternalSuperwallEvent.AdServicesTokenRetrieval(state: .start))
-
-    // Re-check ownership, then create and store the task atomically inside
-    // the queue. `cancelInFlight()` may have fired while we were suspended
-    // on the track call above (before `currentTask` was ever stored), in
-    // which case our pre-reset `existingAttempts` snapshot is now stale and
-    // running runAttempt would clobber the new user's freshly reset storage.
-    // Doing the create+store inside the same sync block also prevents
-    // cancelInFlight from running between Task creation and storage, which
-    // would otherwise leave the task uncancellable from the outside.
+    // Atomic ownership re-check + task creation + store. We don't track
+    // `.start` here — it's deferred into `runAttempt` so we don't leak an
+    // unpaired event if cancelInFlight raced us. Creating and storing the
+    // task inside the same sync block also prevents cancelInFlight from
+    // running between Task() and the store, which would leave the task
+    // uncancellable from the outside.
     let task: Task<Void, Never>? = stateQueue.sync {
       guard ownerGeneration == myGeneration else {
         return nil
@@ -216,6 +212,13 @@ final class AttributionPoster {
     if storage.get(AdServicesAttributionUnsupportedStorage.self) == true {
       return false
     }
+    // No-token environment (simulator without SUPERWALL_MOCK_AD_SERVICES_TOKEN,
+    // build without AdServices.framework). Skip without burning an attempt —
+    // the developer might add the env var and relaunch, or this might just
+    // be the simulator path of a build that works on real devices.
+    if !attributionFetcher.canProduceAdServicesToken {
+      return false
+    }
     guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
       return false
     }
@@ -232,6 +235,14 @@ final class AttributionPoster {
 
   @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
   private func runAttempt(existingAttempts: AdServicesAttributionAttempts?) async {
+    // Fire `.start` from inside the task body so the event isn't orphaned if
+    // `cancelInFlight` raced the outer call's ownership re-check. If we're
+    // already cancelled by the time this runs, skip — no `.start`, no orphan.
+    if Task.isCancelled {
+      return
+    }
+    await Superwall.shared.track(InternalSuperwallEvent.AdServicesTokenRetrieval(state: .start))
+
     let token: String
     do {
       token = try await fetchTokenWithBackoff()
@@ -239,7 +250,12 @@ final class AttributionPoster {
       // Cancellation means `cancelInFlight` (typically via reset) asked us to
       // abandon — not a real failure. Don't bookkeep an attempt, especially
       // because storage may have just been wiped and `existingAttempts` is
-      // stale; writing it would inflate the new user's attempt count.
+      // stale; writing it would inflate the new user's attempt count. We
+      // still emit a terminal so the prior `.start` isn't orphaned in
+      // analytics.
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(CancellationError()))
+      )
       return
     } catch let error as PosterError where error == .permanentlyUnsupported {
       // Don't burn the attempt budget on a device that will never have a
@@ -285,6 +301,12 @@ final class AttributionPoster {
         Superwall.shared.setUserAttributes(attribution)
       }
     } catch is CancellationError {
+      // `.complete(token)` was already emitted above, but the post never
+      // finished — emit a terminal `.fail` so the session has an unambiguous
+      // outcome rather than trailing off after `.complete`.
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(CancellationError()))
+      )
       return
     } catch {
       recordFailedAttempt(existing: existingAttempts)

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -19,10 +19,12 @@ final class AttributionPoster {
   static let maxAttempts = 8
 
   /// Maximum window from the first attempt during which we'll keep retrying.
-  /// Apple's attribution data is only useful within ~24h of install, so 48h
-  /// gives generous slack for the very-first launch happening late in the
-  /// window without continuing indefinitely.
-  static let maxRetryWindow: TimeInterval = 48 * 60 * 60
+  /// Apple's docs say the attribution token is valid for 24h after it's
+  /// generated and that posts should happen within that window. We generate
+  /// a fresh token on every attempt, but the first attempt's clock is what
+  /// bounds Apple's install-side attribution data — past 24h, even a fresh
+  /// token won't resolve to a campaign.
+  static let maxRetryWindow: TimeInterval = 24 * 60 * 60
 
   /// In-session retry plan for transient errors from `AAAttribution.attributionToken()`,
   /// which can throw `networkError` if called too soon after launch. The HTTP

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -68,12 +68,15 @@ final class AttributionPoster {
 
   @available(iOS 14.3, *)
   private func listenToConfig() {
-    // Don't use `.first` here: if the dashboard flips Apple Search Ads from
-    // disabled to enabled mid-session we still want to react.
+    // Track the enabled flag across config refreshes. `removeDuplicates` has
+    // to see the toggles to detect a transition, so we dedup on the bool
+    // *before* filtering. This fires once when the flag first becomes true,
+    // and again if it goes true → false → true mid-session.
     configManager.configState
       .compactMap { $0.getConfig() }
-      .filter { $0.attribution?.appleSearchAds?.enabled == true }
-      .removeDuplicates { _, _ in true } // only trigger once per process
+      .map { $0.attribution?.appleSearchAds?.enabled == true }
+      .removeDuplicates()
+      .filter { $0 }
       .sink(
         receiveCompletion: { _ in },
         receiveValue: { [weak self] _ in

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -300,7 +300,10 @@ final class AttributionPoster {
     var lastError: Error?
     for delay in [0.0] + Self.tokenFetchBackoff {
       if delay > 0 {
-        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        // Propagate cancellation from the sleep itself — using `try?` would
+        // swallow CancellationError and force callers waiting up to 15s for
+        // the next post-sleep `Task.isCancelled` check to notice.
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
       }
       if Task.isCancelled {
         throw CancellationError()

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -157,6 +157,12 @@ final class AttributionPoster {
       return
     }
 
+    // This device permanently can't provide an attribution token (missing
+    // entitlement, unsupported platform). Stop retrying.
+    if storage.get(AdServicesAttributionUnsupportedStorage.self) == true {
+      return
+    }
+
     guard configManager.config?.attribution?.appleSearchAds?.enabled == true else {
       return
     }
@@ -194,7 +200,10 @@ final class AttributionPoster {
       // stale; writing it would inflate the new user's attempt count.
       return
     } catch let error as PosterError where error == .permanentlyUnsupported {
-      // Don't burn the attempt budget on a device that will never have a token.
+      // Don't burn the attempt budget on a device that will never have a
+      // token, but do persist a sentinel so subsequent launches short-circuit
+      // instead of repeating the doomed SDK call indefinitely.
+      storage.save(true, forType: AdServicesAttributionUnsupportedStorage.self)
       await Superwall.shared.track(
         InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(error))
       )

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -57,6 +57,8 @@ final class AttributionPoster {
     self.configManager = configManager
     self.attributionFetcher = attributionFetcher
 
+    Self.migrateLegacyTokenSentinelIfNeeded(storage: storage)
+
     if #available(iOS 14.3, *) {
       listenToConfig()
     }
@@ -107,6 +109,38 @@ final class AttributionPoster {
       }
     }
     #endif
+  }
+
+  /// Moves the AdServices token sentinel from the legacy user-specific
+  /// location to the new app-specific location on first launch after upgrade.
+  /// Without this, existing users would look "never attributed" and we'd
+  /// hammer Apple with retries even though we already finished for them.
+  private static func migrateLegacyTokenSentinelIfNeeded(storage: Storage) {
+    if storage.get(AdServicesTokenStorage.self) != nil {
+      return
+    }
+    guard let legacyToken = storage.get(LegacyUserScopedAdServicesTokenStorage.self) else {
+      return
+    }
+    storage.save(legacyToken, forType: AdServicesTokenStorage.self)
+    // We don't delete the legacy file — its on-disk key collides with the
+    // new one in the memCache layer, so a delete would evict the entry we
+    // just wrote. The orphan file is ~50 bytes and harmless.
+  }
+
+  /// Re-applies the cached ASA attribution dict to the current user's
+  /// attributes. Called from `reset(duringIdentify:)` after user files are
+  /// wiped so the new user identity inherits the install-scoped campaign
+  /// keys without us re-hitting Apple. No-op if nothing was ever fetched.
+  func reapplyCachedAttribution() {
+    guard let cached = storage.get(AdServicesAttributionDataStorage.self) else {
+      return
+    }
+    let attribution = convertJSONToDictionary(attribution: cached)
+    if attribution.isEmpty {
+      return
+    }
+    Superwall.shared.setUserAttributes(attribution)
   }
 
   /// Cancel any in-flight attempt. Used during reset so we don't race a
@@ -258,10 +292,11 @@ final class AttributionPoster {
       if Task.isCancelled {
         return
       }
-      let attribution = convertJSONToDictionary(attribution: response.attribution)
       storage.save(token, forType: AdServicesTokenStorage.self)
+      storage.save(response.attribution, forType: AdServicesAttributionDataStorage.self)
       storage.delete(AdServicesAttributionAttemptsStorage.self)
 
+      let attribution = convertJSONToDictionary(attribution: response.attribution)
       if !attribution.isEmpty {
         Superwall.shared.setUserAttributes(attribution)
       }
@@ -322,8 +357,15 @@ final class AttributionPoster {
     }
     storage.save(updated, forType: AdServicesAttributionAttemptsStorage.self)
   }
+}
 
-  private static func isPermanentTokenError(_ error: Error) -> Bool {
+private enum PosterError: Error, Equatable {
+  case tokenUnavailable
+  case permanentlyUnsupported
+}
+
+extension AttributionPoster {
+  static func isPermanentTokenError(_ error: Error) -> Bool {
     // AAAttributionErrorCode is not consistently exposed as a typed enum
     // across SDK versions, so match on the NSError domain/code numerically.
     // Codes 2 (.platformNotSupported) and 3 (.attributionUnsupported) are
@@ -333,10 +375,5 @@ final class AttributionPoster {
       return false
     }
     return nsError.code == 2 || nsError.code == 3
-  }
-
-  private enum PosterError: Error, Equatable {
-    case tokenUnavailable
-    case permanentlyUnsupported
   }
 }

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -24,10 +24,11 @@ final class AttributionPoster {
   /// window without continuing indefinitely.
   private static let maxRetryWindow: TimeInterval = 48 * 60 * 60
 
-  /// In-session retry plan for transient errors at the SDK or network layer.
-  /// Backoff grows so a single bad-network pocket doesn't burn through the
-  /// per-install attempt budget.
-  private static let inSessionBackoff: [TimeInterval] = [2, 6, 15]
+  /// In-session retry plan for transient errors from `AAAttribution.attributionToken()`,
+  /// which can throw `networkError` if called too soon after launch. The HTTP
+  /// post to our backend is already covered by `Task.retrying` inside
+  /// `CustomURLSession`, so we don't add an outer backoff there.
+  private static let tokenFetchBackoff: [TimeInterval] = [2, 6, 15]
 
   private let stateQueue = DispatchQueue(label: "com.superwall.attributionposter.state")
   private var isCollecting = false
@@ -215,7 +216,12 @@ final class AttributionPoster {
     )
 
     do {
-      let response = try await postTokenWithBackoff(token: token)
+      // CustomURLSession already wraps the request in Task.retrying (3
+      // attempts × 5s for the AdServices endpoint, see Endpoint.swift), so
+      // we don't need our own outer backoff here. Persistent failures fall
+      // through to recordFailedAttempt and the next launch picks up via the
+      // cross-launch attempt budget.
+      let response = try await network.sendToken(token)
       if Task.isCancelled {
         return
       }
@@ -257,7 +263,7 @@ final class AttributionPoster {
   @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
   private func fetchTokenWithBackoff() async throws -> String {
     var lastError: Error?
-    for delay in [0.0] + Self.inSessionBackoff {
+    for delay in [0.0] + Self.tokenFetchBackoff {
       if delay > 0 {
         try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
       }
@@ -277,29 +283,6 @@ final class AttributionPoster {
       }
     }
     throw lastError ?? PosterError.tokenUnavailable
-  }
-
-  /// Sends the token to our backend, retrying transient failures with
-  /// backoff. `CustomURLSession` already retries the HTTP call internally —
-  /// these retries cover the case where every internal retry fails but a
-  /// short pause yields a different result (e.g. Apple's attribution endpoint
-  /// catching up post-install).
-  private func postTokenWithBackoff(token: String) async throws -> AdServicesResponse {
-    var lastError: Error?
-    for delay in [0.0] + Self.inSessionBackoff {
-      if delay > 0 {
-        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-      }
-      if Task.isCancelled {
-        throw CancellationError()
-      }
-      do {
-        return try await network.sendToken(token)
-      } catch {
-        lastError = error
-      }
-    }
-    throw lastError ?? NetworkError.unknown
   }
 
   private func recordFailedAttempt(existing: AdServicesAttributionAttempts?) {

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -16,13 +16,13 @@ final class AttributionPoster {
   /// unhealthy for short periods around install, so we want enough retries to
   /// survive that, but not so many that we keep hammering it for users who
   /// will never have attribution data.
-  private static let maxAttempts = 8
+  static let maxAttempts = 8
 
   /// Maximum window from the first attempt during which we'll keep retrying.
   /// Apple's attribution data is only useful within ~24h of install, so 48h
   /// gives generous slack for the very-first launch happening late in the
   /// window without continuing indefinitely.
-  private static let maxRetryWindow: TimeInterval = 48 * 60 * 60
+  static let maxRetryWindow: TimeInterval = 48 * 60 * 60
 
   /// In-session retry plan for transient errors from `AAAttribution.attributionToken()`,
   /// which can throw `networkError` if called too soon after launch. The HTTP

--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift
@@ -216,8 +216,20 @@ final class AttributionPoster {
       if Task.isCancelled {
         return
       }
-      // The backend can explicitly tell us this user wasn't from Search Ads —
-      // treat that the same as success so we stop retrying.
+      // A non-nil `error` means the backend (or Apple, via the backend)
+      // couldn't resolve attribution for this token. Treat as a retryable
+      // failure rather than burying it under the success sentinel.
+      if let backendError = response.error {
+        throw NSError(
+          domain: "com.superwall.attributionposter",
+          code: -1,
+          userInfo: [NSLocalizedDescriptionKey: backendError]
+        )
+      }
+      // `eligible == false` is a definitive answer from Apple ("this user
+      // wasn't from Search Ads") — fall through to the success path so we
+      // save the sentinel and stop retrying. Same outcome as a non-empty
+      // attribution; only the user-attribute write is skipped.
       let attribution = convertJSONToDictionary(attribution: response.attribution)
       storage.save(token, forType: AdServicesTokenStorage.self)
       storage.delete(AdServicesAttributionAttemptsStorage.self)
@@ -229,6 +241,9 @@ final class AttributionPoster {
       return
     } catch {
       recordFailedAttempt(existing: existingAttempts)
+      await Superwall.shared.track(
+        InternalSuperwallEvent.AdServicesTokenRetrieval(state: .fail(error))
+      )
     }
   }
 

--- a/Sources/SuperwallKit/Models/AdServicesResponse.swift
+++ b/Sources/SuperwallKit/Models/AdServicesResponse.swift
@@ -9,4 +9,11 @@ import Foundation
 
 struct AdServicesResponse: Decodable {
   let attribution: [String: JSON]
+
+  // Apple's attribution endpoint can confirm a user is ineligible (e.g. they
+  // didn't come from a Search Ads campaign). When the backend forwards that
+  // signal we can stop retrying — distinct from a transient failure where the
+  // payload simply hasn't arrived yet.
+  let eligible: Bool?
+  let error: String?
 }

--- a/Sources/SuperwallKit/Models/AdServicesResponse.swift
+++ b/Sources/SuperwallKit/Models/AdServicesResponse.swift
@@ -8,12 +8,10 @@
 import Foundation
 
 struct AdServicesResponse: Decodable {
+  // Backend (`paywall-next:/apple-search-ads/token`) returns
+  // `{ status: "ok", attribution: {...} }` on success. Error states come
+  // back as non-2xx with `{ status: "error", error: "..." }`, but those are
+  // thrown by `CustomURLSession`'s Task.retrying before we ever decode the
+  // body, so we only model the success shape here.
   let attribution: [String: JSON]
-
-  // Apple's attribution endpoint can confirm a user is ineligible (e.g. they
-  // didn't come from a Search Ads campaign). When the backend forwards that
-  // signal we can stop retrying — distinct from a transient failure where the
-  // payload simply hasn't arrived yet.
-  let eligible: Bool?
-  let error: String?
 }

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -308,13 +308,12 @@ class Network {
     }
   }
 
-  func sendToken(_ token: String) async -> [String: Any] {
+  func sendToken(_ token: String) async throws -> AdServicesResponse {
     do {
-      let jsonDict = try await urlSession.request(
+      return try await urlSession.request(
         .adServices(token: token),
         data: SuperwallRequestData(factory: factory)
-      ).attribution
-      return convertJSONToDictionary(attribution: jsonDict)
+      )
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -323,7 +322,7 @@ class Network {
         info: ["payload": token],
         error: error
       )
-      return [:]
+      throw error
     }
   }
 

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -209,11 +209,18 @@ enum LatestEnrichment: Storable {
   typealias Value = Enrichment
 }
 
+/// Apple Search Ads attribution is install-scoped — the campaign that drove
+/// the install doesn't change when a user logs out and another user logs in
+/// on the same device. So all the AdServices state lives in
+/// `.appSpecificDocuments`, surviving `reset(duringIdentify:)`. The cached
+/// attribution dict (``AdServicesAttributionDataStorage``) is re-applied to
+/// the new user's attributes after a reset so they pick up the same
+/// `apple_search_ads_*` / `acquisition_*` keys without re-fetching.
 enum AdServicesTokenStorage: Storable {
   static var key: String {
     "store.adServicesToken"
   }
-  static var directory: SearchPathDirectory = .userSpecificDocuments
+  static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = String
 }
 
@@ -228,7 +235,7 @@ enum AdServicesAttributionAttemptsStorage: Storable {
   static var key: String {
     "store.adServicesAttributionAttempts"
   }
-  static var directory: SearchPathDirectory = .userSpecificDocuments
+  static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = AdServicesAttributionAttempts
 }
 
@@ -241,8 +248,34 @@ enum AdServicesAttributionUnsupportedStorage: Storable {
   static var key: String {
     "store.adServicesAttributionUnsupported"
   }
-  static var directory: SearchPathDirectory = .userSpecificDocuments
+  static var directory: SearchPathDirectory = .appSpecificDocuments
   typealias Value = Bool
+}
+
+/// The decoded attribution payload from the backend, cached so we can
+/// re-apply it to a new user's attributes after `reset(duringIdentify:)`.
+/// Install-scoped: the same campaign keys apply to whichever user is logged
+/// in on this install.
+enum AdServicesAttributionDataStorage: Storable {
+  static var key: String {
+    "store.adServicesAttributionData"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = [String: JSON]
+}
+
+/// Read-side shim for the pre-install-scoped location of the token sentinel.
+/// Older SDK versions wrote ``AdServicesTokenStorage`` to user-specific
+/// documents. On first launch after upgrade we migrate that value over to the
+/// new app-specific location so existing users aren't re-attempted.
+enum LegacyUserScopedAdServicesTokenStorage: Storable {
+  static var key: String {
+    // Same key string as AdServicesTokenStorage so we hit the same on-disk
+    // filename, just in the legacy directory.
+    "store.adServicesToken"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = String
 }
 
 enum SK2TransactionIds: Storable {

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -232,6 +232,19 @@ enum AdServicesAttributionAttemptsStorage: Storable {
   typealias Value = AdServicesAttributionAttempts
 }
 
+/// Set when `AAAttribution.attributionToken()` returns a permanent error
+/// (e.g. `platformNotSupported` / `attributionUnsupported`). Without this,
+/// such devices would re-attempt the SDK call on every launch indefinitely
+/// — the attempt budget doesn't cover them because we intentionally don't
+/// bump it for non-transient errors.
+enum AdServicesAttributionUnsupportedStorage: Storable {
+  static var key: String {
+    "store.adServicesAttributionUnsupported"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = Bool
+}
+
 enum SK2TransactionIds: Storable {
   static var key: String {
     "store.syncedSK2TransactionIds"

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -264,20 +264,6 @@ enum AdServicesAttributionDataStorage: Storable {
   typealias Value = [String: JSON]
 }
 
-/// Read-side shim for the pre-install-scoped location of the token sentinel.
-/// Older SDK versions wrote ``AdServicesTokenStorage`` to user-specific
-/// documents. On first launch after upgrade we migrate that value over to the
-/// new app-specific location so existing users aren't re-attempted.
-enum LegacyUserScopedAdServicesTokenStorage: Storable {
-  static var key: String {
-    // Same key string as AdServicesTokenStorage so we hit the same on-disk
-    // filename, just in the legacy directory.
-    "store.adServicesToken"
-  }
-  static var directory: SearchPathDirectory = .userSpecificDocuments
-  typealias Value = String
-}
-
 enum SK2TransactionIds: Storable {
   static var key: String {
     "store.syncedSK2TransactionIds"

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -217,6 +217,21 @@ enum AdServicesTokenStorage: Storable {
   typealias Value = String
 }
 
+/// Retry bookkeeping for the Apple Search Ads token post.
+///
+/// The presence of an entry under ``AdServicesTokenStorage`` is treated as a
+/// "successfully posted to backend" sentinel. While we're still trying, this
+/// secondary record tracks how many attempts we've made and when, so we can
+/// bound retries (Apple's attribution endpoint only yields useful data within
+/// ~24h of install).
+enum AdServicesAttributionAttemptsStorage: Storable {
+  static var key: String {
+    "store.adServicesAttributionAttempts"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = AdServicesAttributionAttempts
+}
+
 enum SK2TransactionIds: Storable {
   static var key: String {
     "store.syncedSK2TransactionIds"

--- a/Sources/SuperwallKit/Storage/Migration/FileManagerMigrator.swift
+++ b/Sources/SuperwallKit/Storage/Migration/FileManagerMigrator.swift
@@ -13,6 +13,7 @@ enum DataStoreVersion: Int, CaseIterable, Codable {
   case v2
   case v3
   case v4
+  case v5
 }
 
 enum FileManagerMigrator {
@@ -34,6 +35,8 @@ enum FileManagerMigrator {
     case .v3:
       V3Migrator.migrateToNextVersion(cache: cache)
     case .v4:
+      V4Migrator.migrateToNextVersion(cache: cache)
+    case .v5:
       break
     }
 

--- a/Sources/SuperwallKit/Storage/Migration/V4Migrator.swift
+++ b/Sources/SuperwallKit/Storage/Migration/V4Migrator.swift
@@ -1,0 +1,36 @@
+//
+//  V4Migrator.swift
+//  SuperwallKit
+//
+
+import Foundation
+
+/// Pre-v5, the AdServices token sentinel lived in `.userSpecificDocuments` —
+/// it was scoped per-user so that `reset(duringIdentify:)` would wipe it and a
+/// new user could re-fetch. Apple Search Ads attribution is install-scoped
+/// (the campaign that drove the install doesn't change with who's logged in),
+/// so as of v5 the sentinel lives in `.appSpecificDocuments` and survives
+/// `reset`. This shim reads from the legacy directory during migration.
+enum LegacyUserScopedAdServicesTokenStorage: Storable {
+  static var key: String {
+    // Same key string as AdServicesTokenStorage — only the directory differs.
+    "store.adServicesToken"
+  }
+  static var directory: SearchPathDirectory = .userSpecificDocuments
+  typealias Value = String
+}
+
+/// Migrates the AdServices token sentinel from user-specific to app-specific
+/// storage so existing attributed users aren't seen as "never attributed"
+/// after upgrade and re-attempted.
+enum V4Migrator: Migratable {
+  static func migrateToNextVersion(cache: Cache) {
+    if cache.read(AdServicesTokenStorage.self) == nil,
+      let legacyToken = cache.read(LegacyUserScopedAdServicesTokenStorage.self) {
+      cache.write(legacyToken, forType: AdServicesTokenStorage.self)
+      cache.delete(LegacyUserScopedAdServicesTokenStorage.self, fromDirectory: .userSpecificDocuments)
+    }
+
+    cache.write(.v5, forType: Version.self)
+  }
+}

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -1029,6 +1029,11 @@ public final class Superwall: NSObject, ObservableObject {
     dependencyContainer.attributionPoster.cancelInFlight()
     dependencyContainer.storage.reset()
 
+    // ASA attribution is install-scoped, so re-apply the cached campaign
+    // dict to the new user's attributes after the wipe. AdServices state
+    // itself lives in app-specific storage and is preserved through reset.
+    dependencyContainer.attributionPoster.reapplyCachedAttribution()
+
     dependencyContainer.paywallManager.resetCache()
     presentationItems.reset()
     Task {

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -436,15 +436,11 @@ public final class Superwall: NSObject, ObservableObject {
     // This task runs on a background thread, even if called from a main thread.
     // This is because the function isn't marked to run on the main thread,
     // therefore, we don't need to make this detached.
+    //
+    // Note: we don't kick off Apple Search Ads attribution here — it requires
+    // config to be loaded to know whether it's enabled. `AttributionPoster`
+    // subscribes to `configState` and fires automatically once config arrives.
     Task {
-      Task {
-        #if os(iOS) || os(macOS) || os(visionOS)
-          if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
-            await dependencyContainer.attributionPoster.getAdServicesTokenIfNeeded()
-          }
-        #endif
-      }
-
       dependencyContainer.storage.recordAppInstall(trackPlacement: track)
 
       async let fetchConfig: () = await dependencyContainer.configManager.fetchConfiguration()
@@ -1028,6 +1024,9 @@ public final class Superwall: NSObject, ObservableObject {
   /// Asynchronously resets. Presentation of paywalls is suspended until reset completes.
   func reset(duringIdentify: Bool) {
     dependencyContainer.identityManager.reset(duringIdentify: duringIdentify)
+    // Cancel any in-flight attribution post before wiping its storage, so a
+    // late-completing post can't race the new user's state.
+    dependencyContainer.attributionPoster.cancelInFlight()
     dependencyContainer.storage.reset()
 
     dependencyContainer.paywallManager.resetCache()

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		3EA92DE86764CBAC557F8522 /* Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E41300E7467F017BCD5E5C /* Capabilities.swift */; };
 		3F3774A066285BB0DFE61B61 /* JSONToDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09C238ADC0B019047FAB1DF /* JSONToDict.swift */; };
 		3F4BE7ECC80EEA757454F9B6 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124F219E38F8398A65A7EB32 /* DependencyContainer.swift */; };
+		3F6DD6FB62BDF53536FC4EF7 /* V4Migrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D685A5912892EF9C2931B1 /* V4Migrator.swift */; };
 		40314E44991DCB66B4572C25 /* LocationPermissionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4623C4E5EDA10B38746C384 /* LocationPermissionDelegateTests.swift */; };
 		40E6B7996E9BA4B5D65F1432 /* RedemptionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B382F84E55D4D8C37A6021E3 /* RedemptionResult.swift */; };
 		412C74624BB8933162DAAC5F /* Experiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5836EFACFA00594CE8F9F377 /* Experiment.swift */; };
@@ -1052,6 +1053,7 @@
 		C8EE9572F945C698DE4A2EAA /* InternallySetSubscriptionStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternallySetSubscriptionStatusTests.swift; sourceTree = "<group>"; };
 		C937320625239F3E10FE8D8E /* PermissionsHandler+Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PermissionsHandler+Location.swift"; sourceTree = "<group>"; };
 		C9B0C261DCC1ED74DD2BF3EA /* HiddenListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenListener.swift; sourceTree = "<group>"; };
+		C9D685A5912892EF9C2931B1 /* V4Migrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V4Migrator.swift; sourceTree = "<group>"; };
 		CA65A320EE640CDB878F43E9 /* UIWindow+Landscape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Landscape.swift"; sourceTree = "<group>"; };
 		CB7C70BFD23FD038393FD6DC /* PageViewMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewMessageTests.swift; sourceTree = "<group>"; };
 		CB8384E2DB0A3627BE1CCB7D /* PurchasingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasingCoordinator.swift; sourceTree = "<group>"; };
@@ -1214,6 +1216,7 @@
 				4BE6E7AC2E38E0EB43C35AF5 /* V1Migrator.swift */,
 				3A6728F289EC434B1C856BD2 /* V2Migrator.swift */,
 				891BDDF19DEC970709DDF4BB /* V3Migrator.swift */,
+				C9D685A5912892EF9C2931B1 /* V4Migrator.swift */,
 			);
 			path = Migration;
 			sourceTree = "<group>";
@@ -3722,6 +3725,7 @@
 				519196E0035C17C73C525526 /* V2Migrator.swift in Sources */,
 				12A2722FD932939699923E60 /* V2ProductsResponse.swift in Sources */,
 				9F517D76DDEFF5278DDBACC8 /* V3Migrator.swift in Sources */,
+				3F6DD6FB62BDF53536FC4EF7 /* V4Migrator.swift in Sources */,
 				7DCBF8A78D0B6A7A2649553D /* Validation.swift in Sources */,
 				5C504112376B6E0798CA20CE /* Variables.swift in Sources */,
 				DE2F41FF9D70AB13AD246E49 /* VariantOption.swift in Sources */,

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		AE9F583082A5CDCE595BDA2D /* AppSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8165DD71323903F7CF426D2C /* AppSession.swift */; };
 		AEAB0C0C168B0B3D864109EA /* CoreDataManagerFakeDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74C7DE0FAFE0C01F374DDF0 /* CoreDataManagerFakeDataMock.swift */; };
 		AEB9D461AF5103FB7257AD25 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */; };
+		AECD80682E1909735CCDAA78 /* AdServicesAttributionAttempts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D538EA68425ECB218BA3CA /* AdServicesAttributionAttempts.swift */; };
 		AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27F0D55EF3480E2B65C8DFD /* HandleTriggerResultOperatorTests.swift */; };
 		B078481CA0ADD4B4F3BEFD15 /* LocalFileSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0C49F4A92D8C5C05FA026 /* LocalFileSchemeHandler.swift */; };
 		B0AD4A89AD5101360F93652D /* SubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACDC7427B6340E9D86F9B0F /* SubscriptionTransaction.swift */; };
@@ -411,6 +412,7 @@
 		C18384B9272067CFE7C7610D /* StoreProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A959F1F550446C980DC5E5 /* StoreProductType.swift */; };
 		C22C4011CB9F4D4FA99F8206 /* FakeAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673E3BA33A9530AD1168346A /* FakeAudioSession.swift */; };
 		C23744AAAF31A533693281B6 /* SurveyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B5ABEC694245E0DC00E409 /* SurveyManager.swift */; };
+		C2A9B3F073EA27F9CD6FCA02 /* AdServicesAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82783401B92298C47BF14F7 /* AdServicesAttributionTests.swift */; };
 		C32766E26E92FD03B1BA60A3 /* ProductPurchaserSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A56D712042043783D7CA142 /* ProductPurchaserSK1.swift */; };
 		C34A4AF2C8CD9ACBD2C370F8 /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1443B535E6E1D572A74733F /* SubscriptionPeriod.swift */; };
 		C366CDBA75B69D05DC28394A /* WaitForSubsStatusAndConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731F01C2EA1AC1F06AC1499D /* WaitForSubsStatusAndConfig.swift */; };
@@ -953,6 +955,7 @@
 		A7A8FDBB0F8D450288C3FEA0 /* LocalFileSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileSchemeHandlerTests.swift; sourceTree = "<group>"; };
 		A7C3FC26DCBF604D7319FBB2 /* zh_Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_Hant; path = zh_Hant.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A7D0B6F781D32B2DCDBE689C /* PermissionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionHandling.swift; sourceTree = "<group>"; };
+		A82783401B92298C47BF14F7 /* AdServicesAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdServicesAttributionTests.swift; sourceTree = "<group>"; };
 		A94120D51C7B36AC9EA32B8B /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		A99ACA54EC311F399BB025CD /* ProductPurchaserSK2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaserSK2.swift; sourceTree = "<group>"; };
 		AA0B401CD38DBD6D90E4EB3E /* CheckoutWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutWebViewController.swift; sourceTree = "<group>"; };
@@ -1154,6 +1157,7 @@
 		F96ABDCA3686C7F1CAF41B03 /* en_GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en_GB; path = en_GB.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F98F66F7AA2F9F3E96849D8A /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		F9D2422F9742D74360FB716B /* TaskRetryingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRetryingTests.swift; sourceTree = "<group>"; };
+		F9D538EA68425ECB218BA3CA /* AdServicesAttributionAttempts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdServicesAttributionAttempts.swift; sourceTree = "<group>"; };
 		FA3A82C80F89023672D56AD7 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
 		FB28BCE1EE94BFE935B984AB /* DeviceHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHelperTests.swift; sourceTree = "<group>"; };
 		FBE7D1E1AF61D199E17B5C05 /* SWLocalizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWLocalizationViewController.swift; sourceTree = "<group>"; };
@@ -2562,6 +2566,7 @@
 		B24A2445833C9796434E8DA2 /* Attribution */ = {
 			isa = PBXGroup;
 			children = (
+				F9D538EA68425ECB218BA3CA /* AdServicesAttributionAttempts.swift */,
 				AF989B3D90DC3D88FACC4D45 /* ASIdManagerProxy.swift */,
 				64EAB177118BC78B02C3C00A /* AttributionFetcher.swift */,
 				0B31ACE25727649F21DEEBAF /* AttributionPoster.swift */,
@@ -2853,6 +2858,7 @@
 		DEA1A1177CB76234AA134723 /* Attribution */ = {
 			isa = PBXGroup;
 			children = (
+				A82783401B92298C47BF14F7 /* AdServicesAttributionTests.swift */,
 				6B7CFAF4B3E32AE628A249C8 /* AttributionTests.swift */,
 			);
 			path = Attribution;
@@ -3149,7 +3155,7 @@
 			);
 			mainGroup = 5CE8CEF97A892FFF3D0D8F06;
 			packageReferences = (
-				8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */,
+				89F17188BC665EFC6FE5CEFA /* XCRemoteSwiftPackageReference "superscript-ios-next" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -3180,6 +3186,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C2A9B3F073EA27F9CD6FCA02 /* AdServicesAttributionTests.swift in Sources */,
 				9B49485A1CFAC2621A89B150 /* AppSessionLogicTests.swift in Sources */,
 				1E81A71ADE8A5EAD9E609E1D /* AppSessionManagerMock.swift in Sources */,
 				E2E0E2A82200943E73E3A92A /* AppSessionManagerTests.swift in Sources */,
@@ -3317,6 +3324,7 @@
 				E95C8C0485512D77E37703C5 /* ASN1Templates.swift in Sources */,
 				2C7867867DDAD83E5856ECC9 /* ASN1Types.swift in Sources */,
 				5E05FDE4F45BD5B0DF6AFB9F /* ActivityIndicatorView.swift in Sources */,
+				AECD80682E1909735CCDAA78 /* AdServicesAttributionAttempts.swift in Sources */,
 				ED575DD46B84EE351972AC6B /* AdServicesResponse.swift in Sources */,
 				90EE0190126A3BBA4661122E /* AddPaywallProducts.swift in Sources */,
 				14D4EA6EAA43647D24A9716A /* AlertControllerFactory.swift in Sources */,
@@ -4019,7 +4027,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */ = {
+		89F17188BC665EFC6FE5CEFA /* XCRemoteSwiftPackageReference "superscript-ios-next" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/superwall/superscript-ios-next";
 			requirement = {
@@ -4032,7 +4040,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		721C720FA8360B9851DE843D /* Superscript */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 8DF6D231FF02D65F59962D80 /* XCRemoteSwiftPackageReference "superscript-ios-next" */;
+			package = 89F17188BC665EFC6FE5CEFA /* XCRemoteSwiftPackageReference "superscript-ios-next" */;
 			productName = Superscript;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
@@ -133,4 +133,98 @@ struct AdServicesAttributionTests {
     // Should be a no-op when nothing is in flight, but must not crash.
     dependencyContainer.attributionPoster!.cancelInFlight()
   }
+
+  // MARK: - canStartAttempt guards
+  //
+  // We test the guards by setting up storage state where they should bail,
+  // calling `getAdServicesTokenIfNeeded`, and asserting nothing was written
+  // or mutated. The alternative — passing the canStartAttempt guard — would
+  // make a real network call, so every test in this block must arrange for a
+  // bail. Config is left in `.retrieving` state for most of these because the
+  // tests don't depend on the config-enabled branch; the budget / sentinel
+  // checks short-circuit before the config check is reached only when the
+  // config-enabled guard is also failing — that's still a valid bail, and we
+  // assert "nothing changed" either way.
+
+  @Test
+  func getAdServicesToken_bailsWhenMaxAttemptsReached() async {
+    guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+      return
+    }
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+    let poster = dependencyContainer.attributionPoster!
+
+    storage.delete(AdServicesTokenStorage.self)
+    storage.delete(AdServicesAttributionUnsupportedStorage.self)
+    let saturated = AdServicesAttributionAttempts(
+      count: AttributionPoster.maxAttempts,
+      firstAttemptDate: Date(),
+      lastAttemptDate: Date()
+    )
+    storage.save(saturated, forType: AdServicesAttributionAttemptsStorage.self)
+    dependencyContainer.configManager.configState.send(.retrieved(.stub()))
+
+    await poster.getAdServicesTokenIfNeeded()
+
+    // Attempts record must NOT have been bumped — that would mean we tried
+    // anyway, defeating the cap.
+    #expect(storage.get(AdServicesAttributionAttemptsStorage.self) == saturated)
+    #expect(storage.get(AdServicesTokenStorage.self) == nil)
+
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+  }
+
+  @Test
+  func getAdServicesToken_bailsWhenRetryWindowExpired() async {
+    guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+      return
+    }
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+    let poster = dependencyContainer.attributionPoster!
+
+    storage.delete(AdServicesTokenStorage.self)
+    storage.delete(AdServicesAttributionUnsupportedStorage.self)
+    let firstAttempt = Date().addingTimeInterval(-AttributionPoster.maxRetryWindow - 60)
+    let expired = AdServicesAttributionAttempts(
+      count: 2,
+      firstAttemptDate: firstAttempt,
+      lastAttemptDate: firstAttempt.addingTimeInterval(30)
+    )
+    storage.save(expired, forType: AdServicesAttributionAttemptsStorage.self)
+    dependencyContainer.configManager.configState.send(.retrieved(.stub()))
+
+    await poster.getAdServicesTokenIfNeeded()
+
+    #expect(storage.get(AdServicesAttributionAttemptsStorage.self) == expired)
+    #expect(storage.get(AdServicesTokenStorage.self) == nil)
+
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+  }
+
+  @Test
+  func getAdServicesToken_bailsWhenPermanentlyUnsupported() async {
+    guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+      return
+    }
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+    let poster = dependencyContainer.attributionPoster!
+
+    storage.delete(AdServicesTokenStorage.self)
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+    storage.save(true, forType: AdServicesAttributionUnsupportedStorage.self)
+    dependencyContainer.configManager.configState.send(.retrieved(.stub()))
+
+    await poster.getAdServicesTokenIfNeeded()
+
+    // No attempts record written, no success token written — the unsupported
+    // sentinel is a hard stop.
+    #expect(storage.get(AdServicesAttributionAttemptsStorage.self) == nil)
+    #expect(storage.get(AdServicesTokenStorage.self) == nil)
+    #expect(storage.get(AdServicesAttributionUnsupportedStorage.self) == true)
+
+    storage.delete(AdServicesAttributionUnsupportedStorage.self)
+  }
 }

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
@@ -175,6 +175,41 @@ struct AdServicesAttributionTests {
   }
 
   @Test
+  func attributionData_roundTripsThroughStorage() {
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+
+    storage.delete(AdServicesAttributionDataStorage.self)
+
+    let cached: [String: JSON] = [
+      "apple_search_ads_campaign_id": "campaign-123",
+      "acquisition_source": "apple_search_ads"
+    ]
+    storage.save(cached, forType: AdServicesAttributionDataStorage.self)
+
+    let restored = storage.get(AdServicesAttributionDataStorage.self)
+    #expect(restored?["apple_search_ads_campaign_id"]?.stringValue == "campaign-123")
+    #expect(restored?["acquisition_source"]?.stringValue == "apple_search_ads")
+
+    storage.delete(AdServicesAttributionDataStorage.self)
+  }
+
+  @Test
+  func reapplyCachedAttribution_noCrashWhenNothingCached() {
+    // The user-attribute side effect happens on Superwall.shared (the global
+    // singleton) and is detached from the test's local DependencyContainer,
+    // so asserting on the resulting attributes from inside this test isn't
+    // reliable. Just confirm the no-op path doesn't crash with empty state.
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+    let poster = dependencyContainer.attributionPoster!
+
+    storage.delete(AdServicesAttributionDataStorage.self)
+
+    poster.reapplyCachedAttribution()
+  }
+
+  @Test
   func getAdServicesToken_bailsWhenPermanentlyUnsupported() async {
     guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
       return

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
@@ -1,0 +1,136 @@
+//
+//  AdServicesAttributionTests.swift
+//  SuperwallKit
+//
+
+import Foundation
+import Testing
+@testable import SuperwallKit
+
+@Suite
+struct AdServicesAttributionTests {
+  // MARK: - AdServicesResponse decoding
+
+  @Test
+  func adServicesResponse_decodesFullPayload() throws {
+    let json = """
+    {
+      "attribution": {
+        "campaignId": 12345,
+        "keywordId": "kw-1"
+      },
+      "eligible": true,
+      "error": null
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
+
+    #expect(decoded.eligible == true)
+    #expect(decoded.error == nil)
+    #expect(decoded.attribution["campaignId"]?.intValue == 12345)
+    #expect(decoded.attribution["keywordId"]?.stringValue == "kw-1")
+  }
+
+  @Test
+  func adServicesResponse_decodesIneligibleResult() throws {
+    let json = """
+    {
+      "attribution": {},
+      "eligible": false
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
+
+    #expect(decoded.eligible == false)
+    #expect(decoded.error == nil)
+    #expect(decoded.attribution.isEmpty)
+  }
+
+  @Test
+  func adServicesResponse_decodesWithoutOptionalFields() throws {
+    let json = """
+    {
+      "attribution": { "campaignId": 1 }
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
+
+    #expect(decoded.eligible == nil)
+    #expect(decoded.error == nil)
+    #expect(decoded.attribution["campaignId"]?.intValue == 1)
+  }
+
+  // MARK: - AdServicesAttributionAttempts round-trip
+
+  @Test
+  func attempts_roundTripsThroughCodable() throws {
+    let original = AdServicesAttributionAttempts(
+      count: 3,
+      firstAttemptDate: Date(timeIntervalSince1970: 1_700_000_000),
+      lastAttemptDate: Date(timeIntervalSince1970: 1_700_001_000)
+    )
+
+    let data = try JSONEncoder().encode(original)
+    let restored = try JSONDecoder().decode(AdServicesAttributionAttempts.self, from: data)
+
+    #expect(restored == original)
+  }
+
+  @Test
+  func attempts_storageRoundTripsViaCache() {
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+
+    // Make sure we start clean — previous test runs can leave state behind.
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+    #expect(storage.get(AdServicesAttributionAttemptsStorage.self) == nil)
+
+    let attempts = AdServicesAttributionAttempts(
+      count: 2,
+      firstAttemptDate: Date(timeIntervalSince1970: 1_700_000_000),
+      lastAttemptDate: Date(timeIntervalSince1970: 1_700_000_500)
+    )
+    storage.save(attempts, forType: AdServicesAttributionAttemptsStorage.self)
+
+    let restored = storage.get(AdServicesAttributionAttemptsStorage.self)
+    #expect(restored == attempts)
+
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+  }
+
+  // MARK: - AttributionPoster gating
+
+  @Test
+  func getAdServicesToken_noOpsWhenAlreadyPosted() async {
+    guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+      return
+    }
+    let dependencyContainer = DependencyContainer()
+    let storage = dependencyContainer.storage!
+    let poster = dependencyContainer.attributionPoster!
+
+    // Pretend a previous run successfully posted.
+    storage.save("sentinel-token", forType: AdServicesTokenStorage.self)
+    storage.delete(AdServicesAttributionAttemptsStorage.self)
+
+    await poster.getAdServicesTokenIfNeeded()
+
+    // Sentinel should still be there and we should not have recorded a fresh
+    // failed attempt — the poster should have bailed before touching either.
+    #expect(storage.get(AdServicesTokenStorage.self) == "sentinel-token")
+    #expect(storage.get(AdServicesAttributionAttemptsStorage.self) == nil)
+
+    // cleanup
+    storage.delete(AdServicesTokenStorage.self)
+  }
+
+  @Test
+  func cancelInFlight_clearsCollectingFlag() {
+    let dependencyContainer = DependencyContainer()
+    // Should be a no-op when nothing is in flight, but must not crash.
+    dependencyContainer.attributionPoster!.cancelInFlight()
+  }
+}

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
@@ -7,7 +7,7 @@ import Foundation
 import Testing
 @testable import SuperwallKit
 
-@Suite
+@Suite(.serialized)
 struct AdServicesAttributionTests {
   // MARK: - AdServicesResponse decoding
 

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift
@@ -12,55 +12,26 @@ struct AdServicesAttributionTests {
   // MARK: - AdServicesResponse decoding
 
   @Test
-  func adServicesResponse_decodesFullPayload() throws {
+  func adServicesResponse_decodesBackendSuccessShape() throws {
+    // Matches paywall-next:/apple-search-ads/token success body:
+    //   { "status": "ok", "attribution": { ... } }
+    // We don't model `status`; we just need attribution to decode.
     let json = """
     {
+      "status": "ok",
       "attribution": {
-        "campaignId": 12345,
-        "keywordId": "kw-1"
-      },
-      "eligible": true,
-      "error": null
+        "apple_search_ads_campaign_id": "12345",
+        "apple_search_ads_keyword_id": "kw-1",
+        "acquisition_source": "apple_search_ads"
+      }
     }
     """.data(using: .utf8)!
 
     let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
 
-    #expect(decoded.eligible == true)
-    #expect(decoded.error == nil)
-    #expect(decoded.attribution["campaignId"]?.intValue == 12345)
-    #expect(decoded.attribution["keywordId"]?.stringValue == "kw-1")
-  }
-
-  @Test
-  func adServicesResponse_decodesIneligibleResult() throws {
-    let json = """
-    {
-      "attribution": {},
-      "eligible": false
-    }
-    """.data(using: .utf8)!
-
-    let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
-
-    #expect(decoded.eligible == false)
-    #expect(decoded.error == nil)
-    #expect(decoded.attribution.isEmpty)
-  }
-
-  @Test
-  func adServicesResponse_decodesWithoutOptionalFields() throws {
-    let json = """
-    {
-      "attribution": { "campaignId": 1 }
-    }
-    """.data(using: .utf8)!
-
-    let decoded = try JSONDecoder().decode(AdServicesResponse.self, from: json)
-
-    #expect(decoded.eligible == nil)
-    #expect(decoded.error == nil)
-    #expect(decoded.attribution["campaignId"]?.intValue == 1)
+    #expect(decoded.attribution["apple_search_ads_campaign_id"]?.stringValue == "12345")
+    #expect(decoded.attribution["apple_search_ads_keyword_id"]?.stringValue == "kw-1")
+    #expect(decoded.attribution["acquisition_source"]?.stringValue == "apple_search_ads")
   }
 
   // MARK: - AdServicesAttributionAttempts round-trip

--- a/Tests/SuperwallKitTests/Storage/Migration/FileManagerMigratorTests.swift
+++ b/Tests/SuperwallKitTests/Storage/Migration/FileManagerMigratorTests.swift
@@ -12,7 +12,7 @@ import Foundation
 
 struct FileManagerMigratorTests {
   @Test
-  func migrateFromV1ToV4() {
+  func migrateFromV1ToV5() {
     let cache = CacheMock()
 
     // Write all possible values to the cache.
@@ -57,9 +57,9 @@ struct FileManagerMigratorTests {
     #expect(newAssignments?.first?.experimentId == experimentId)
     #expect(newAssignments?.first?.variant == variant)
 
-    // Check the new version is v4
+    // Check the new version is v5
     let version = cache.read(Version.self)
-    #expect(version == .v4)
+    #expect(version == .v5)
   }
 
   @Test
@@ -117,5 +117,52 @@ struct FileManagerMigratorTests {
     // Check the new version is v4
     let version = cache.read(Version.self)
     #expect(version == .v4)
+  }
+
+  @Test
+  func migrateAdServicesTokenFromV4ToV5() {
+    let cache = CacheMock()
+
+    // Pre-v5 state: token sentinel in user-specific docs.
+    cache.write("legacy-token", forType: LegacyUserScopedAdServicesTokenStorage.self)
+    cache.write(.v4, forType: Version.self)
+
+    #expect(cache.read(LegacyUserScopedAdServicesTokenStorage.self) == "legacy-token")
+    #expect(cache.read(AdServicesTokenStorage.self) == nil)
+
+    V4Migrator.migrateToNextVersion(cache: cache)
+
+    // Token moved to app-specific, legacy file gone.
+    #expect(cache.read(AdServicesTokenStorage.self) == "legacy-token")
+    #expect(cache.read(LegacyUserScopedAdServicesTokenStorage.self) == nil)
+    #expect(cache.read(Version.self) == .v5)
+  }
+
+  @Test
+  func migrateAdServicesTokenFromV4ToV5_noLegacyData() {
+    let cache = CacheMock()
+    cache.write(.v4, forType: Version.self)
+
+    V4Migrator.migrateToNextVersion(cache: cache)
+
+    // Nothing to migrate — version still bumps to v5.
+    #expect(cache.read(AdServicesTokenStorage.self) == nil)
+    #expect(cache.read(Version.self) == .v5)
+  }
+
+  @Test
+  func migrateAdServicesTokenFromV4ToV5_doesntOverwriteExisting() {
+    let cache = CacheMock()
+
+    // Both legacy and new exist (shouldn't happen in practice, but defend
+    // against it — the new value wins).
+    cache.write("legacy", forType: LegacyUserScopedAdServicesTokenStorage.self)
+    cache.write("current", forType: AdServicesTokenStorage.self)
+    cache.write(.v4, forType: Version.self)
+
+    V4Migrator.migrateToNextVersion(cache: cache)
+
+    #expect(cache.read(AdServicesTokenStorage.self) == "current")
+    #expect(cache.read(Version.self) == .v5)
   }
 }


### PR DESCRIPTION
## Changes in this pull request

Makes the Apple Search Ads / AdServices integration substantially more reliable. The original code saved the token sentinel *before* the backend round-trip, so a single transient failure (Apple's endpoint not ready post-install, brief network blip, etc.) permanently lost attribution for that install. It also wiped state on `reset(duringIdentify:)` and re-fetched per user, which fails silently past Apple's 24h install window. This PR rebuilds the flow around two pivots: write the sentinel only after success (so failures can be retried across launches), and treat attribution as install-scoped (so new user identities on the same device inherit the campaign data without re-fetching).

### What changed

- **`Network.sendToken`** throws instead of swallowing errors into `[:]`, so the caller can drive retries.
- **`AttributionPoster`**:
  - Only writes `AdServicesTokenStorage` after the backend round-trip confirms; failures bump a separate attempt counter (`AdServicesAttributionAttemptsStorage`) so the next launch picks up.
  - In-session backoff (2s, 6s, 15s) for `AAAttribution.attributionToken()`, which Apple documents as throwing `networkError` if called too soon after launch.
  - HTTP retries for the backend post are left to `CustomURLSession.request`'s existing `Task.retrying` (3×5s for this endpoint) rather than stacked outer backoff.
  - Cross-launch retry budget: 8 attempts within 24h of first attempt (matches Apple's documented token validity window).
  - `AAAttributionErrorCode.platformNotSupported` (the only documented permanent error) writes a dedicated `AdServicesAttributionUnsupportedStorage` sentinel so we don't retry forever on devices that can't produce a token. `internalError` and `networkError` stay in the transient bucket.
  - Thread-safe single-flight via serial queue + monotonic `ownerGeneration` stamp on each outer call so a late-completing call's `defer` can't clobber state belonging to a newly started call.
  - `cancelInFlight()` called from `reset(duringIdentify:)` — and the in-flight task is created+stored atomically with an ownership re-check, closing the race window between the `track(.start)` suspension and `currentTask` being written.
  - Foreground retry priority bumped from `.background` to `.utility` (background tasks can be deferred indefinitely under load).
  - `listenToConfig` is now keyed off `removeDuplicates() → filter { $0 }` on the enabled bool, so toggling Apple Search Ads off then on mid-session still triggers a fetch (the previous `.first { ... }` only fired once per process).
  - Dead `getAdServicesTokenIfNeeded()` kickoff removed from `Superwall.configure()` — it always bailed at the config-enabled guard because config wasn't loaded yet; the `configState` sink handles the first fetch.
- **Install-scoped attribution**:
  - All AdServices storables move to `.appSpecificDocuments` so they survive `reset(duringIdentify:)`.
  - New `AdServicesAttributionDataStorage` caches the decoded attribution dict.
  - New `AttributionPoster.reapplyCachedAttribution()` is wired into `reset(duringIdentify:)` after `storage.reset()` wipes user files, so the new user identity inherits the same `apple_search_ads_*` / `acquisition_*` keys without re-hitting Apple.
- **Migration**: `V4Migrator` (the existing project pattern) moves the legacy user-scoped token sentinel into the new app-scoped location on first launch after upgrade and deletes the legacy file. Existing attributed users aren't seen as "never attributed" and re-attempted.
- **`AttributionFetcher.identifierForAdvertisers`** filters the all-zeros UUID sentinel iOS returns when ATT is denied, so we stop polluting attribution payloads with junk IDFAs.

### Tests

- 10 tests in `AdServicesAttributionTests` covering: decoder shape, attempts round-trip, `canStartAttempt` guards (max attempts, retry window, permanently unsupported, already-posted), cache round-trip for the attribution dict, `cancelInFlight` no-crash, `reapplyCachedAttribution` no-op.
- 3 tests for `V4Migrator` (happy path, no-legacy-data, doesn't-overwrite-existing).
- Existing `migrateFromV1ToV4` renamed → `migrateFromV1ToV5`; final version expectation bumped.
- Race / concurrency / cancellation scenarios are not unit-tested — they'd need a `NetworkMock.sendToken` override and an injectable `AAAttribution` seam, neither of which exists yet. Tracked separately.

### Checklist

- [x] All unit tests pass. (One pre-existing, unrelated `CustomProductTests` failure not in this diff.)
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR substantially rebuilds the Apple Search Ads attribution pipeline around two correctness pivots: write the success sentinel only after the backend round-trip confirms (so transient failures are retried across launches), and treat attribution as install-scoped rather than user-scoped (so a new user identity on the same device inherits the campaign data without re-hitting Apple).

- **`AttributionPoster`** is rewritten with a serial-queue single-flight guard, monotonic generation stamps, in-session backoff (2s / 6s / 15s), an 8-attempt cross-launch budget, `cancelInFlight()` for reset coordination, and `reapplyCachedAttribution()` to replay stored campaign keys to the new user after `reset(duringIdentify:)`.
- **Storage scoping**: all four new AdServices storables (`AdServicesTokenStorage`, `AdServicesAttributionAttemptsStorage`, `AdServicesAttributionUnsupportedStorage`, `AdServicesAttributionDataStorage`) are moved/added to `.appSpecificDocuments` so they survive `reset()`.
- **`V4Migrator`** (new) promotes the legacy user-scoped token sentinel to app-scoped so existing attributed users aren't re-attempted after upgrade; `Network.sendToken` now throws instead of swallowing errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The rewrite is logically sound and the two suggestions are non-blocking data-hygiene items.

The attribution flow is well-structured: single-flight guard uses a proven generation-stamp pattern, all four storage keys are correctly app-scoped, cancellation is handled at every async suspension point, and the 8-attempt / 24h budget is clearly documented. The only substantive gap is that the success sentinel is written one line before the cached attribution dict — a process crash in that window leaves reapplyCachedAttribution() as a permanent no-op for that install, though the current session's user already received the ASA keys. The V4Migrator cleanup gap is benign in practice. Neither issue affects correctness in the common case.

The save-ordering in AttributionPoster.runAttempt (lines 295–297) and the legacy-file cleanup in V4Migrator.migrateToNextVersion are the only spots worth a second look before shipping.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift | Core rewrite of ASA attribution: adds serial-queue single-flight, generation-stamped ownership, in-session backoff, cross-launch attempt budget, reapplyCachedAttribution, and cancelInFlight. Attribution sentinel is written before cached attribution data (minor crash-safety ordering issue). |
| Sources/SuperwallKit/Storage/Migration/V4Migrator.swift | New migrator moves AdServices token sentinel from user-scoped to app-scoped storage; does not delete the legacy file when the new-location file already exists. |
| Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift | Adds all-zeros IDFA sentinel filter and canProduceAdServicesToken environment guard; straightforward and correct. |
| Sources/SuperwallKit/Storage/Cache/CacheKeys.swift | Adds three new app-scoped storables (attempts, unsupported sentinel, cached attribution dict) and moves AdServicesTokenStorage to .appSpecificDocuments; clean and consistent with existing patterns. |
| Sources/SuperwallKit/Network/Network.swift | sendToken now throws instead of swallowing errors into an empty dict; correct change that enables caller-driven retries. |
| Sources/SuperwallKit/Superwall.swift | Removes premature getAdServicesTokenIfNeeded call from configure (config not loaded yet); adds cancelInFlight + reapplyCachedAttribution to reset(duringIdentify:) in the correct order. |
| Tests/SuperwallKitTests/Analytics/Attribution/AdServicesAttributionTests.swift | 10 new tests covering decoder, storage round-trips, and all canStartAttempt guards; good coverage of the gating logic. |
| Tests/SuperwallKitTests/Storage/Migration/FileManagerMigratorTests.swift | Adds V4→V5 migration tests (happy path, no legacy data, doesn't overwrite); the doesn't-overwrite test doesn't assert the legacy file was cleaned up, consistent with the current migrator behaviour. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App launch / foreground / config enabled] --> B[getAdServicesTokenIfNeeded]
    B --> C{isCollecting?}
    C -- yes --> Z[return - single flight]
    C -- no --> D[canStartAttempt checks]
    D --> D1{AdServicesTokenStorage exists?}
    D1 -- yes --> Z2[return - already posted]
    D1 -- no --> D2{AdServicesAttributionUnsupportedStorage?}
    D2 -- yes --> Z3[return - permanent fail]
    D2 -- no --> D3{canProduceAdServicesToken?}
    D3 -- no --> Z4[return - simulator/no framework]
    D3 -- yes --> D4{config enabled?}
    D4 -- no --> Z5[return]
    D4 -- yes --> D5{attempt budget / 24h window?}
    D5 -- exceeded --> Z6[return]
    D5 -- ok --> E[runAttempt]
    E --> F[fetchTokenWithBackoff 4 tries: 0s/2s/6s/15s]
    F -- CancellationError --> G[emit fail event, return]
    F -- platformNotSupported --> H[save AdServicesAttributionUnsupportedStorage]
    F -- other error --> I[recordFailedAttempt bumps cross-launch counter]
    F -- token --> J[network.sendToken]
    J -- CancellationError --> K[emit fail event, return]
    J -- error --> I
    J -- success --> L[save AdServicesAttributionDataStorage]
    L --> M[save AdServicesTokenStorage sentinel]
    M --> N[delete AdServicesAttributionAttemptsStorage]
    N --> O[setUserAttributes with ASA keys]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/SuperwallKit/Analytics/Attribution/AttributionPoster.swift:295-297
Attribution sentinel written before cached data — a crash in this narrow window permanently skips `reapplyCachedAttribution()`. If the process terminates after saving `AdServicesTokenStorage` but before `AdServicesAttributionDataStorage`, the success sentinel blocks all future retries yet the cached dict is missing, so subsequent `reapplyCachedAttribution()` calls (e.g., after every user `reset()`) are no-ops and the new user never gets ASA keys. Swapping the order so the sentinel is written last makes the system crash-idempotent: if the crash is before the sentinel, the next launch retries harmlessly; if after, the cached dict is guaranteed to be present.

```suggestion
      storage.save(response.attribution, forType: AdServicesAttributionDataStorage.self)
      storage.save(token, forType: AdServicesTokenStorage.self)
      storage.delete(AdServicesAttributionAttemptsStorage.self)
```

### Issue 2 of 2
Sources/SuperwallKit/Storage/Migration/V4Migrator.swift:27-35
When both the legacy and new-location files exist (e.g., a user who somehow wrote the app-scoped file before migration), the `if` guard exits early without ever deleting the legacy file. The stale file lingers in `.userSpecificDocuments` until the next `storage.reset()`. Deleting the legacy file unconditionally after the conditional write matches the intent of the migration.

```suggestion
  static func migrateToNextVersion(cache: Cache) {
    if cache.read(AdServicesTokenStorage.self) == nil,
      let legacyToken = cache.read(LegacyUserScopedAdServicesTokenStorage.self) {
      cache.write(legacyToken, forType: AdServicesTokenStorage.self)
    }
    // Always remove the legacy file regardless of which branch was taken above.
    cache.delete(LegacyUserScopedAdServicesTokenStorage.self, fromDirectory: .userSpecificDocuments)

    cache.write(.v5, forType: Version.self)
  }
```

`````

</details>

<sub>Reviews (12): Last reviewed commit: ["Pair every analytics .start with a termi..."](https://github.com/superwall/superwall-ios/commit/90722d8ccdc9d07bc3bdcfb14e324ca2cfbae00d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31956443)</sub>

<!-- /greptile_comment -->