### PR TITLE
Use non-optional UUID init for zero-IDFA sentinel

### DIFF
--- a/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift
@@ -56,7 +56,10 @@ final class AttributionFetcher {
     return nil
   }
 
-  private static let zeroAdvertisingIdentifier = UUID(uuidString: "00000000-0000-0000-0000-000000000000")
+  // Non-optional construction via `init(uuid:)` — `init(uuidString:)` returns
+  // an Optional which would make the equality check silently false-positive
+  // if the literal ever failed to parse.
+  private static let zeroAdvertisingIdentifier = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 
   /// Whether this build/environment can ever produce an AdServices token.
   /// `false` on builds that didn't link AdServices.framework and on debug


### PR DESCRIPTION
## Summary

Follow-up to #470. The reviewer flagged that `private static let zeroAdvertisingIdentifier = UUID(uuidString: "...")` types the constant as `UUID?` — if the literal ever failed to parse (impossible for this constant, but the type allows it), the equality check at the call site would be `nil != identifierValue → false` and the zero-IDFA would slip through unfiltered.

`UUID` has a non-optional `init(uuid: uuid_t)` that takes the 16-byte tuple directly. Switching to that removes the optionality without needing a force-unwrap.

## Test plan
- [x] swiftlint clean
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps the zero-IDFA sentinel constant from `UUID(uuidString:)` (which produces `UUID?`) to `UUID(uuid:)` with a 16-byte all-zero tuple (which produces a non-optional `UUID`), closing a theoretical type-safety gap introduced in PR #470.

- The sentinel `zeroAdvertisingIdentifier` is now typed as `UUID` rather than `UUID?`, so the `==` comparison against `identifierValue` is unambiguous and can never silently evaluate to `false` due to a `nil` optional.
- The new comment in the file mis-labels the failure mode as "false-positive" when it is actually a false-negative (the filter fails to catch the zero IDFA); the code change itself is correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line constant change correctly removes optionality from the zero-IDFA sentinel, and the only finding is a word choice error in the explanatory comment.

The fix is minimal, targeted, and mechanically correct: `UUID(uuid:)` with all-zero bytes produces the same value as the old string literal but as a non-optional type, so the equality check is now unconditionally well-typed. The only thing flagged is that the comment describes the failure mode as a 'false-positive' when it is actually a false-negative.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift | Replaces `UUID(uuidString:)` (returns `UUID?`) with `UUID(uuid:)` (returns `UUID`) for the zero-IDFA sentinel constant, eliminating the optionality and making the equality check unconditionally correct. Only issue is a minor terminology error in the new comment. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AttributionFetcher
    participant ASIdentifierManager

    Caller->>AttributionFetcher: identifierForAdvertisers
    AttributionFetcher->>ASIdentifierManager: adsIdentifier
    ASIdentifierManager-->>AttributionFetcher: UUID? (nil or value)
    alt adsIdentifier is nil
        AttributionFetcher-->>Caller: nil
    else adsIdentifier is UUID
        AttributionFetcher->>AttributionFetcher: "identifierValue == zeroAdvertisingIdentifier (UUID == UUID, always valid)"
        alt identifierValue is all-zeros sentinel
            AttributionFetcher-->>Caller: nil (filtered)
        else identifierValue is real IDFA
            AttributionFetcher-->>Caller: identifierValue.uuidString
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/SuperwallKit/Analytics/Attribution/AttributionFetcher.swift:59-61
The comment says "silently false-positive" but the failure mode is a false-negative: if `zeroAdvertisingIdentifier` were `nil`, the equality check would return `false`, the `if` block would not fire, and the all-zeros IDFA would pass through unfiltered — the opposite of a false-positive.

```suggestion
  // Non-optional construction via `init(uuid:)` — `init(uuidString:)` returns
  // an Optional which would make the equality check silently false-negative
  // (zero-IDFA passes through unfiltered) if the literal ever failed to parse.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Use non-optional UUID init for zero-IDFA..."](https://github.com/superwall/superwall-ios/commit/16b81240470e4f07660ef8769013d7343a4845bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32165288)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->