### PR TITLE
Fix day↔week price conversion (6.99 weekly shows as 7.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.15.3
+
+### Fixes
+
+- Fixes computed period prices (`weeklyPrice`, `dailyPrice`) being off by a small amount for products whose subscription period is expressed in days. A 7-day product is exactly one week, but the day↔week conversion went through an approximate `52/365` factor, so a 7-day product priced at e.g. £6.99 could report a `weeklyPrice` of £7.00. Day↔week conversions are now exact.
+
 ## 4.15.2
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
-- Changes the Superscript spm package repo source to a new lightweight repo meaning that the download of the package is way faster.
+- Changes the Superscript SPM package repo source to a new lightweight repo meaning that the download of the package is way faster.
 
 ## 4.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
-- Fixes computed period prices (`weeklyPrice`, `dailyPrice`) being off by a small amount for products whose subscription period is expressed in days. A 7-day product is exactly one week, but the day↔week conversion went through an approximate `52/365` factor, so a 7-day product priced at e.g. £6.99 could report a `weeklyPrice` of £7.00. Day↔week conversions are now exact.
+- Fixes computed period prices (`weeklyPrice`, `dailyPrice`) being off by a small amount for products whose subscription period is expressed in days.
 
 ## 4.15.2
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.15.2
+4.15.3
 """

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/APIStoreProduct.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/APIStoreProduct.swift
@@ -194,7 +194,7 @@ struct APIStoreProduct: StoreProductType {
     let days: Decimal
     switch unit {
     case .day: days = Decimal(subscriptionValue)
-    case .week: days = Decimal(365) / Decimal(52) * Decimal(subscriptionValue)
+    case .week: days = Decimal(7) * Decimal(subscriptionValue)
     case .month: days = Decimal(365) / Decimal(12) * Decimal(subscriptionValue)
     case .year: days = Decimal(365 * subscriptionValue)
     @unknown default: days = 1
@@ -209,7 +209,7 @@ struct APIStoreProduct: StoreProductType {
     }
     let weeks: Decimal
     switch unit {
-    case .day: weeks = Decimal(subscriptionValue) * Decimal(52) / Decimal(365)
+    case .day: weeks = Decimal(subscriptionValue) / Decimal(7)
     case .week: weeks = Decimal(subscriptionValue)
     case .month: weeks = Decimal(52) / Decimal(12) * Decimal(subscriptionValue)
     case .year: weeks = Decimal(52 * subscriptionValue)

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SK2StoreProduct.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SK2StoreProduct.swift
@@ -263,108 +263,34 @@ struct SK2StoreProduct: StoreProductType {
   }
 
   var dailyPrice: String {
-    guard let subscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
-      return "n/a"
-    }
-
-    let numberOfUnits = subscriptionPeriod.value
-    var periods: Decimal = 1.0
-    let inputPrice = underlyingSK2Product.price
-
-    switch subscriptionPeriod.unit {
-    case .year:
-      periods = Decimal(365 * numberOfUnits)
-    case .month:
-      periods = Decimal(365) / Decimal(12) * Decimal(numberOfUnits)
-    case .week:
-      // 7 days per week exactly — not 365/52.
-      periods = Decimal(7) * Decimal(numberOfUnits)
-    case .day:
-      periods = Decimal(numberOfUnits)
-    @unknown default:
-      periods = Decimal(numberOfUnits)
-    }
-
-    let result = (inputPrice / periods).roundedPrice()
-    return priceFormatter.string(from: NSDecimalNumber(decimal: result)) ?? "n/a"
+    return formattedComputedPrice { $0.pricePerDay(withTotalPrice: $1) }
   }
 
   var weeklyPrice: String {
-    guard let subscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
-      return "n/a"
-    }
-
-    let numberOfUnits = subscriptionPeriod.value
-    var periods: Decimal = 1.0
-    let inputPrice = underlyingSK2Product.price
-
-    switch subscriptionPeriod.unit {
-    case .year:
-      periods = Decimal(52 * numberOfUnits)
-    case .month:
-      periods = Decimal(52) / Decimal(12) * Decimal(numberOfUnits)
-    case .week:
-      periods = Decimal(numberOfUnits)
-    case .day:
-      // 7 days per week exactly — a 7-day product is 1 week.
-      periods = Decimal(numberOfUnits) / Decimal(7)
-    @unknown default:
-      periods = Decimal(numberOfUnits)
-    }
-
-    let result = (inputPrice / periods).roundedPrice()
-    return priceFormatter.string(from: NSDecimalNumber(decimal: result)) ?? "n/a"
+    return formattedComputedPrice { $0.pricePerWeek(withTotalPrice: $1) }
   }
 
   var monthlyPrice: String {
-    guard let subscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
-      return "n/a"
-    }
-
-    let numberOfUnits = subscriptionPeriod.value
-    var periods: Decimal = 1.0
-    let inputPrice = underlyingSK2Product.price
-
-    switch subscriptionPeriod.unit {
-    case .year:
-      periods = Decimal(12 * numberOfUnits)
-    case .month:
-      periods = Decimal(1 * numberOfUnits)
-    case .week:
-      periods = Decimal(numberOfUnits) * Decimal(12) / Decimal(52)
-    case .day:
-      periods = Decimal(numberOfUnits) * Decimal(12) / Decimal(365)
-    @unknown default:
-      periods = Decimal(numberOfUnits)
-    }
-
-    let result = (inputPrice / periods).roundedPrice()
-    return priceFormatter.string(from: NSDecimalNumber(decimal: result)) ?? "n/a"
+    return formattedComputedPrice { $0.pricePerMonth(withTotalPrice: $1) }
   }
 
   var yearlyPrice: String {
-    guard let subscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
+    return formattedComputedPrice { $0.pricePerYear(withTotalPrice: $1) }
+  }
+
+  /// Formats a per-period price derived from the *normalized* subscription
+  /// period. `subscriptionPeriod` is built via `SubscriptionPeriod.from(...)`,
+  /// which applies `normalized()` — collapsing StoreKit's occasional `.day × 7`
+  /// into `.week × 1`. Without that, a weekly product reported by StoreKit in
+  /// days would divide by an approximate day↔week factor and report a
+  /// `weeklyPrice` a penny off (e.g. £6.99 → £7.00).
+  private func formattedComputedPrice(
+    _ perPeriod: (SubscriptionPeriod, Decimal) -> Decimal
+  ) -> String {
+    guard let subscriptionPeriod = subscriptionPeriod else {
       return "n/a"
     }
-
-    let numberOfUnits = subscriptionPeriod.value
-    var periods: Decimal = 1.0
-    let inputPrice = underlyingSK2Product.price
-
-    switch subscriptionPeriod.unit {
-    case .year:
-      periods = Decimal(numberOfUnits)
-    case .month:
-      periods = Decimal(numberOfUnits) / Decimal(12)
-    case .week:
-      periods = Decimal(numberOfUnits) / Decimal(52)
-    case .day:
-      periods = Decimal(numberOfUnits) / Decimal(365)
-    @unknown default:
-      periods = Decimal(numberOfUnits)
-    }
-
-    let result = (inputPrice / periods).roundedPrice()
+    let result = perPeriod(subscriptionPeriod, underlyingSK2Product.price)
     return priceFormatter.string(from: NSDecimalNumber(decimal: result)) ?? "n/a"
   }
 

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SK2StoreProduct.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SK2StoreProduct.swift
@@ -277,7 +277,8 @@ struct SK2StoreProduct: StoreProductType {
     case .month:
       periods = Decimal(365) / Decimal(12) * Decimal(numberOfUnits)
     case .week:
-      periods = Decimal(365) / Decimal(52) * Decimal(numberOfUnits)
+      // 7 days per week exactly — not 365/52.
+      periods = Decimal(7) * Decimal(numberOfUnits)
     case .day:
       periods = Decimal(numberOfUnits)
     @unknown default:
@@ -305,7 +306,8 @@ struct SK2StoreProduct: StoreProductType {
     case .week:
       periods = Decimal(numberOfUnits)
     case .day:
-      periods = Decimal(numberOfUnits) * Decimal(52) / Decimal(365)
+      // 7 days per week exactly — a 7-day product is 1 week.
+      periods = Decimal(numberOfUnits) / Decimal(7)
     @unknown default:
       periods = Decimal(numberOfUnits)
     }

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/StripeProductType.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/StripeProductType.swift
@@ -299,7 +299,8 @@ struct StripeProductType: StoreProductType {
     }
 
     if subscriptionPeriod.unit == .week {
-      periods = Decimal(365) / Decimal(52) * Decimal(numberOfUnits)
+      // 7 days per week exactly — not 365/52.
+      periods = Decimal(7) * Decimal(numberOfUnits)
     }
 
     if subscriptionPeriod.unit == .day {
@@ -338,7 +339,8 @@ struct StripeProductType: StoreProductType {
     }
 
     if subscriptionPeriod.unit == .day {
-      periods = Decimal(numberOfUnits) * Decimal(52) / Decimal(365)
+      // 7 days per week exactly — a 7-day product is 1 week.
+      periods = Decimal(numberOfUnits) / Decimal(7)
     }
 
     let rounded = (price / periods).roundedPrice()

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SubscriptionPeriod.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SubscriptionPeriod.swift
@@ -107,7 +107,7 @@ public final class SubscriptionPeriod: NSObject, Sendable {
   /// Occasionally, StoreKit seems to send back a value 7 days for a 7day trial
   /// instead of a value of 1 week for a trial of 7 days in length.
   /// Source: https://github.com/RevenueCat/react-native-purchases/issues/348
-  private func normalized() -> SubscriptionPeriod {
+  func normalized() -> SubscriptionPeriod {
     switch unit {
     case .day:
       if value.isMultiple(of: 7) {

--- a/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SubscriptionPeriod.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/StoreProduct/SubscriptionPeriod.swift
@@ -131,7 +131,10 @@ extension SubscriptionPeriod {
     let periodsPerDay: Decimal = {
       switch self.unit {
       case .day: return 1
-      case .week: return Decimal(365) / Decimal(52)
+      // A week is exactly 7 days. Don't route through 52/365 — 52 weeks is
+      // only 364 days, so that approximation makes a 1-week product's daily
+      // price disagree with an equivalent 7-day product's.
+      case .week: return 7
       case .month: return Decimal(365) / Decimal(12)
       case .year: return 365
       }
@@ -145,7 +148,9 @@ extension SubscriptionPeriod {
   func pricePerWeek(withTotalPrice price: Decimal) -> Decimal {
     let periodsPerWeek: Decimal = {
       switch self.unit {
-      case .day: return Decimal(52) / Decimal(365)
+      // A day is exactly 1/7 of a week. The old 52/365 made a 7-day product
+      // resolve to 0.997 weeks, inflating its weekly price (e.g. 6.99 → 7.00).
+      case .day: return Decimal(1) / Decimal(7)
       case .week: return 1
       case .month: return Decimal(52) / Decimal(12)
       case .year: return 52

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.15.2"
+  s.version      = "4.15.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/SubscriptionPeriodPriceTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/SubscriptionPeriodPriceTests.swift
@@ -119,6 +119,30 @@ struct SubscriptionPeriodPriceTests {
     #expect(weeklyPrice == Decimal(string: "4.99"))
   }
 
+  @Test("Weekly price for a 7-day subscription equals the price")
+  func testWeeklyPriceForSevenDaySubscription() {
+    // A 7-day period IS one week, so the weekly price must equal the price.
+    // Before the day↔week conversion fix this divided by (7 × 52/365) ≈ 0.9973,
+    // giving 6.99 / 0.9973 ≈ 7.009, which truncated to "7.00" — a penny too high.
+    let period = SubscriptionPeriod(value: 7, unit: .day)
+    let weeklyPrice = period.pricePerWeek(withTotalPrice: Decimal(string: "6.99")!)
+
+    #expect(weeklyPrice == Decimal(string: "6.99"))
+  }
+
+  @Test("7-day and 1-week subscriptions produce the same weekly price")
+  func testSevenDayAndOneWeekWeeklyPriceAreConsistent() {
+    // The two are the same duration — their derived weekly price must match.
+    let price = Decimal(string: "6.99")!
+    let sevenDay = SubscriptionPeriod(value: 7, unit: .day)
+    let oneWeek = SubscriptionPeriod(value: 1, unit: .week)
+
+    #expect(
+      sevenDay.pricePerWeek(withTotalPrice: price)
+        == oneWeek.pricePerWeek(withTotalPrice: price)
+    )
+  }
+
   // MARK: - Monthly Price Tests
 
   @Test("Monthly price for yearly subscription")

--- a/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/SubscriptionPeriodPriceTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/SubscriptionPeriodPriceTests.swift
@@ -57,6 +57,29 @@ struct SubscriptionPeriodPriceTests {
     #expect(dailyPrice == Decimal(string: "0.99"))
   }
 
+  @Test("Daily price for a 1-week subscription divides by exactly 7")
+  func testDailyPriceForWeeklySubscriptionDividesBySeven() {
+    // A week is exactly 7 days. Before the day↔week fix this divided by
+    // 365/52 ≈ 7.019, giving 7.00 / 7.019 ≈ 0.9973 → "0.99" — a penny too low.
+    let period = SubscriptionPeriod(value: 1, unit: .week)
+    let dailyPrice = period.pricePerDay(withTotalPrice: Decimal(string: "7.00")!)
+
+    #expect(dailyPrice == Decimal(string: "1.00"))
+  }
+
+  @Test("7-day and 1-week subscriptions produce the same daily price")
+  func testSevenDayAndOneWeekDailyPriceAreConsistent() {
+    // The two are the same duration — their derived daily price must match.
+    let price = Decimal(string: "7.00")!
+    let sevenDay = SubscriptionPeriod(value: 7, unit: .day)
+    let oneWeek = SubscriptionPeriod(value: 1, unit: .week)
+
+    #expect(
+      sevenDay.pricePerDay(withTotalPrice: price)
+        == oneWeek.pricePerDay(withTotalPrice: price)
+    )
+  }
+
   @Test("Daily price for multi-month subscription")
   func testDailyPriceForThreeMonthSubscription() {
     // $24.99/3 months should be ~$0.27/day (24.99 / 90)
@@ -245,5 +268,47 @@ struct SubscriptionPeriodPriceTests {
 
     // 0.99 / 365 = 0.00271... rounds down to 0.00
     #expect(dailyPrice == Decimal(string: "0.00"))
+  }
+
+  // MARK: - Normalization
+
+  // StoreKit sometimes reports a weekly subscription as `.day × 7` rather than
+  // `.week × 1`. `normalized()` collapses day/month multiples so the computed
+  // price logic (and `SK2StoreProduct`, which routes through it) treats a
+  // 7-day product as exactly one week — otherwise its weekly price came out a
+  // penny high (e.g. £6.99 → £7.00).
+
+  @Test("A 7-day period normalizes to 1 week")
+  func testSevenDayPeriodNormalizesToOneWeek() {
+    let normalized = SubscriptionPeriod(value: 7, unit: .day).normalized()
+
+    #expect(normalized.value == 1)
+    #expect(normalized.unit == .week)
+  }
+
+  @Test("A 14-day period normalizes to 2 weeks")
+  func testFourteenDayPeriodNormalizesToTwoWeeks() {
+    let normalized = SubscriptionPeriod(value: 14, unit: .day).normalized()
+
+    #expect(normalized.value == 2)
+    #expect(normalized.unit == .week)
+  }
+
+  @Test("A non-7-multiple day period stays in days")
+  func testThreeDayPeriodStaysInDays() {
+    let normalized = SubscriptionPeriod(value: 3, unit: .day).normalized()
+
+    #expect(normalized.value == 3)
+    #expect(normalized.unit == .day)
+  }
+
+  @Test("Normalized 7-day period yields a weekly price equal to the price")
+  func testNormalizedSevenDayWeeklyPriceEqualsPrice() {
+    // The full chain: a 7-day period normalizes to 1 week, and the weekly
+    // price of a 1-week product is the price itself.
+    let normalized = SubscriptionPeriod(value: 7, unit: .day).normalized()
+    let weeklyPrice = normalized.pricePerWeek(withTotalPrice: Decimal(string: "6.99")!)
+
+    #expect(weeklyPrice == Decimal(string: "6.99"))
   }
 }


### PR DESCRIPTION
## Summary

A customer reported a 7-day £6.99 product showing `weeklyPrice` as £7.00 on the live paywall, while the StoreKit purchase sheet (and the paywall editor) correctly showed £6.99.

### Root cause

Two compounding issues:

1. **Approximate day↔week conversion.** The computed-price logic converted days↔weeks via a `52/365` factor. But 52 weeks = 364 days, not 365 — so a 7-day period resolved to ~0.997 weeks instead of exactly 1.
2. **`SK2StoreProduct` bypassed normalization.** StoreKit sometimes reports a weekly subscription as `.day × 7` rather than `.week × 1`. The SDK has `SubscriptionPeriod.normalized()` to collapse that to `.week × 1`, but `SK2StoreProduct`'s price getters switched directly on the *raw* StoreKit period and never called it — so a weekly product hit the day↔week branch and `6.99 / 0.997 ≈ 7.009` truncated to `7.00`.

## Changes

- **Exact day↔week conversion** (7 days = 1 week) in all computed-price paths: the `SubscriptionPeriod` helper and the inline switches in `SK2StoreProduct`, `APIStoreProduct`, `StripeProductType`.
- **`SK2StoreProduct` now routes through the normalized period.** The four price getters (`dailyPrice`/`weeklyPrice`/`monthlyPrice`/`yearlyPrice`) were replaced with calls through the existing normalized `subscriptionPeriod` property and its `pricePerDay/Week/Month/Year` helpers. A StoreKit `.day × 7` now collapses to `.week × 1` before the math runs, so a weekly product's weekly price equals its price. This also removes the duplicated per-getter conversion logic.
- Month↔year was already exact (12); week↔month / week↔year stay as conventional approximations — those aren't whole-number relationships.
- `SubscriptionPeriod.normalized()` made internal for testability.
- Version bumped to 4.15.3 (Constants.swift, podspec, CHANGELOG).

## Tests

`SubscriptionPeriodPriceTests` — 28 tests, incl. new coverage:
- `weeklyPrice` / `dailyPrice` for a 7-day period (pre-fix produced the penny-off value).
- 7-day vs 1-week consistency for both weekly and daily prices.
- Normalization: 7-day → 1 week, 14-day → 2 weeks, 3-day stays in days, and the full chain (7-day normalized → `weeklyPrice` equals the price).

`SK2StoreProduct`'s getters can't be unit-tested directly (`StoreKit.Product` isn't constructible in tests); the normalization + helper tests cover the logic they now route through.

## Test plan
- [x] All unit tests pass
- [x] Build passes
- [x] swiftlint clean

## Follow-up
`APIStoreProduct` and `StripeProductType` still carry their own inline conversion switches (now arithmetically correct). Consolidating all four product types onto the `SubscriptionPeriod` helper as the single source of truth would prevent this class of bug recurring per-file — worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a penny-off price display bug where a 7-day £6.99 subscription showed `weeklyPrice` as £7.00. The root causes were an imprecise `52/365` day↔week conversion factor and `SK2StoreProduct`'s price getters bypassing the existing `normalized()` function that collapses StoreKit's occasional `.day × 7` encoding into `.week × 1`.

- **Arithmetic fix**: `52/365` replaced with exact `7` / `1/7` in `SubscriptionPeriod`, `APIStoreProduct`, and `StripeProductType`.
- **Normalization fix**: `SK2StoreProduct`'s four inline price getters replaced with a single `formattedComputedPrice` helper routing through the normalized `subscriptionPeriod` property.
- **Testability**: `normalized()` promoted from `private` to `internal` for direct test access.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it makes two well-scoped arithmetic corrections directly verified by the new tests.

Both fixes are narrow, independently testable, and the new test suite exercises the exact scenario that produced the original bug. The SK2StoreProduct refactor removes duplication rather than adding new logic paths.

No files require special attention. APIStoreProduct and StripeProductType still carry inline switches but are arithmetically correct after this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/StoreKit/Products/StoreProduct/SubscriptionPeriod.swift | Core fix: `.week` periodsPerDay changed from `365/52` to exact `7`; `.day` periodsPerWeek changed from `52/365` to exact `1/7`. `normalized()` promoted to `internal` for test access. |
| Sources/SuperwallKit/StoreKit/Products/StoreProduct/SK2StoreProduct.swift | Replaced four duplicated per-getter price switch statements with a single `formattedComputedPrice` helper routing through the normalized `subscriptionPeriod` property. |
| Sources/SuperwallKit/StoreKit/Products/StoreProduct/APIStoreProduct.swift | Inline day-week conversion constants corrected from `365/52` and `52/365` to exact `7` and `1/7`. |
| Sources/SuperwallKit/StoreKit/Products/StoreProduct/StripeProductType.swift | Same arithmetic correction as APIStoreProduct for daily/weekly price inline switches. |
| Tests/SuperwallKitTests/StoreKit/Products/StoreProduct/SubscriptionPeriodPriceTests.swift | New tests cover: weekly price equality for 7-day period, 7-day/1-week consistency, daily price for 1-week period, and the full normalization chain. |
| CHANGELOG.md | 4.15.3 entry added with accurate description of the computed price fix. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SK2[SK2StoreProduct] --> FCP[formattedComputedPrice helper]
    FCP --> SP[subscriptionPeriod property]
    SP --> NRM[normalized: day x7 to week x1]
    NRM --> HELPER[pricePerDay / pricePerWeek / pricePerMonth / pricePerYear]
    HELPER --> MATH_W[.week: periodsPerDay = 7 x value EXACT]
    HELPER --> MATH_D[.day: periodsPerWeek = value / 7 EXACT]
    MATH_W --> ROUND[NSDecimalNumber rounding down scale 2]
    MATH_D --> ROUND
    ROUND --> OUT[Formatted price string]
    API[APIStoreProduct and StripeProductType] --> INLINE[Inline switches day-week now exact 7]
    INLINE --> ROUND
```

<sub>Reviews (2): Last reviewed commit: ["Route SK2 computed prices through the no..."](https://github.com/superwall/superwall-ios/commit/9b1635c56a95902cf5b469740549c170cc762186) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32317631)</sub>

<!-- /greptile_comment -->