### PR TITLE
Fix data race on preloading task causing swift_release crash

### DIFF
--- a/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Advanced/Advanced.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "3bbaa4a88d74c863ee5bc4295b2fc628323eff0d",
-          "version": "5.75.0"
+          "revision": "6935da62be3f33f06ed16e9e49431fe9e10e1426",
+          "version": "5.79.0"
         }
       },
       {

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -44,8 +44,9 @@ class ConfigManager {
   private unowned let webEntitlementRedeemer: WebEntitlementRedeemer
   let expressionEvaluator: CELEvaluator
 
-  /// A task that is non-`nil` when preloading all paywalls.
-  private var currentPreloadingTask: Task<Void, Never>?
+  /// Serializes preloading so concurrent callers can't race on the task
+  /// reference. See ``preloadAllPaywalls()``.
+  private let preloadingCoordinator = PreloadingTaskCoordinator()
 
   typealias Factory = RequestFactory
     & AudienceFilterAttributesFactory
@@ -565,13 +566,16 @@ class ConfigManager {
 
   /// Preloads paywalls referenced by triggers.
   func preloadAllPaywalls() async {
-    currentPreloadingTask = Task { [weak self, currentPreloadingTask] in
+    // Chain onto any in-flight preload through the coordinator. The coordinator
+    // is an actor, so swapping in the new task is serialized. Previously this was
+    // `self.currentPreloadingTask = Task { ... }` on a non-isolated class, so
+    // concurrent callers (config refresh, retry, reset, public API) raced on the
+    // task reference and over-released it, crashing in `swift_release` during
+    // task teardown.
+    await preloadingCoordinator.enqueue { [weak self] in
       guard let self = self else {
         return
       }
-      // Wait until the previous task is finished before continuing.
-      await currentPreloadingTask?.value
-
       guard
         let config = try? await self.configState
           .compactMap({ $0.getConfig() })
@@ -606,6 +610,23 @@ class ConfigManager {
         paywallIds.remove(presentedPaywallId)
       }
       await self.preloadPaywalls(withIdentifiers: paywallIds)
+    }
+  }
+
+  /// Serializes the read-modify-write of the preloading task so it can't be
+  /// mutated from multiple tasks at once. Each enqueued operation runs only
+  /// after the previously enqueued one finishes, preserving the original
+  /// chaining behavior while making the swap data-race free.
+  private actor PreloadingTaskCoordinator {
+    private var currentTask: Task<Void, Never>?
+
+    /// Atomically chains `operation` after any in-flight preloading task.
+    func enqueue(_ operation: @escaping @Sendable () async -> Void) {
+      let previous = currentTask
+      currentTask = Task {
+        await previous?.value
+        await operation()
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent **over-release / double-free** that crashes in `swift_release_dealloc` on the cooperative pool (seen in the wild via Crashlytics during paywall preloading).

`ConfigManager.preloadAllPaywalls()` swapped the preloading task with an **unsynchronized read-modify-write** on the non-isolated `ConfigManager` class:

```swift
currentPreloadingTask = Task { [weak self, currentPreloadingTask] in ... }
```

`preloadAllPaywalls()` is kicked off from several places — config-fetch success, retry, `reset()`, and the public `Superwall.preloadAllPaywalls()` — a number of them wrapped in their own `Task {}`. When two run concurrently on `com.apple.root.default-qos.cooperative`, they race on the task reference and over-release the previous task, producing a double-free that faults in `swift_release_dealloc` during task teardown.

## Fix

Move the task reference into a small `PreloadingTaskCoordinator` **actor**. Its `enqueue` performs the "read previous → build chained task → store it" sequence under actor isolation, so the swap is serialized and can never be torn.

Behavior is unchanged — each preload still awaits the previous one before running (`await previous?.value; await operation()`); the swap is just race-free now.

## Why not make `ConfigManager` an actor

A full actor conversion ripples into synchronous reads of `config`, `triggersByPlacementName`, and `configRetryCount` across `DependencyContainer`, `DeepLinkRouter`, `EvaluateRules`, and `Tracking` — a large, risky change for a crash hotfix. Isolating just the racy task pointer fixes the actual crash with a small, reviewable diff.

## Testing

- `xcodebuild -scheme SuperwallKit -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**, no new errors/warnings in `ConfigManager.swift`.
- The closure capture is identical in sendability to the original `Task {}`, so no new strict-concurrency diagnostics.

## Follow-up (not in this PR)

`triggersByPlacementName` and `configRetryCount` are also mutated in the config-fetch flow while read synchronously from other threads — a separate latent data race, not the cause of this crash. Worth hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)