### PR TITLE
Add EventTrackingBehavior for GDPR-compliant event control (v4.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,9 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Enhancements
 
+- Adds support for annual subscriptions that are billed monthly.
 - Added `EventTrackingBehavior` enum and `SuperwallOptions.eventTrackingBehavior` property for GDPR-compliant event collection control. Use `.all` (default) to track everything, `.superwallOnly` to suppress user-initiated tracking, trigger fires, and user-attribute updates while keeping internal SDK events, or `.none` to stop all event collection entirely. The behavior can also be changed at runtime via `Superwall.shared.eventTrackingBehavior`.
 - Deprecated `SuperwallOptions.isExternalDataCollectionEnabled`. Setting it to `false` now maps to `.superwallOnly`; setting it back to `true` maps to `.all`.
-
-## 4.15.4
-
-### Enhancements
-
-- Adds support for annual subscriptions that are billed monthly.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.16.0
+
+### Enhancements
+
+- Added `EventTrackingBehavior` enum and `SuperwallOptions.eventTrackingBehavior` property for GDPR-compliant event collection control. Use `.all` (default) to track everything, `.superwallOnly` to suppress user-initiated tracking, trigger fires, and user-attribute updates while keeping internal SDK events, or `.none` to stop all event collection entirely. The behavior can also be changed at runtime via `Superwall.shared.eventTrackingBehavior`.
+- Deprecated `SuperwallOptions.isExternalDataCollectionEnabled`. Setting it to `false` now maps to `.superwallOnly`; setting it back to `true` maps to `.all`.
+
 ## 4.15.4
 
 ### Enhancements

--- a/Sources/SuperwallKit/Config/Options/EventTrackingBehavior.swift
+++ b/Sources/SuperwallKit/Config/Options/EventTrackingBehavior.swift
@@ -1,0 +1,41 @@
+//
+//  EventTrackingBehavior.swift
+//
+//
+//  Created by Yusuf Tör on 22/06/2026.
+//
+
+import Foundation
+
+/// Controls which events are sent to the Superwall servers.
+///
+/// Use ``SuperwallOptions/eventTrackingBehavior`` or set ``Superwall/eventTrackingBehavior``
+/// at runtime to change event collection at any time.
+///
+/// - `.all`: All events are tracked (default).
+/// - `.superwallOnly`: Only internal Superwall events are tracked. User-initiated
+///   ``Superwall/track(event:params:)`` calls, trigger fires, and user-attribute updates
+///   are suppressed. Equivalent to the deprecated `isExternalDataCollectionEnabled = false`.
+/// - `.none`: No events are sent to the Superwall servers.
+@objc(SWKEventTrackingBehavior)
+public enum EventTrackingBehavior: Int, CustomStringConvertible, Encodable, Sendable {
+  /// All events are tracked. This is the default.
+  case all = 0
+
+  /// Only internal Superwall events are tracked.
+  ///
+  /// User-initiated tracking calls, trigger-fire events, and user-attribute
+  /// updates are suppressed. All other internal SDK events continue to be sent.
+  case superwallOnly = 1
+
+  /// No events are sent to the Superwall servers.
+  case none = 2
+
+  public var description: String {
+    switch self {
+    case .all: return "all"
+    case .superwallOnly: return "superwallOnly"
+    case .none: return "none"
+    }
+  }
+}

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -297,12 +297,30 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// - Note: You cannot use ``Superwall/purchase(_:)`` while this is `true`.
   public var shouldObservePurchases = false
 
+  /// Controls which events are sent to the Superwall servers.
+  ///
+  /// Defaults to ``EventTrackingBehavior/all``. Set this to ``EventTrackingBehavior/superwallOnly``
+  /// to suppress user-initiated tracking, trigger fires, and user-attribute updates, or to
+  /// ``EventTrackingBehavior/none`` to stop all event collection (e.g. for GDPR compliance).
+  ///
+  /// You can also change this at runtime via ``Superwall/eventTrackingBehavior``.
+  public var eventTrackingBehavior: EventTrackingBehavior = .all
+
   /// Enables the sending of non-Superwall tracked events and properties back to the Superwall servers.
   /// Defaults to `true`.
   ///
-  /// Set this to `false` to stop external data collection. This will not affect
-  /// your ability to create placements based on properties.
-  public var isExternalDataCollectionEnabled = true
+  /// - Warning: Deprecated. Use ``eventTrackingBehavior`` instead.
+  ///   Setting this to `false` maps to ``EventTrackingBehavior/superwallOnly``;
+  ///   setting it back to `true` maps to ``EventTrackingBehavior/all``.
+  @available(*, deprecated, renamed: "eventTrackingBehavior")
+  public var isExternalDataCollectionEnabled: Bool {
+    get {
+      return eventTrackingBehavior == .all
+    }
+    set {
+      eventTrackingBehavior = newValue ? .all : .superwallOnly
+    }
+  }
 
   /// Sets the device locale identifier to use when evaluating audience filters.
   ///
@@ -374,7 +392,7 @@ public final class SuperwallOptions: NSObject, Encodable {
   public var logging = Logging()
 
   private enum CodingKeys: String, CodingKey {
-    case isExternalDataCollectionEnabled
+    case eventTrackingBehavior
     case localeIdentifier
     case isGameControllerEnabled
     case storeKitVersion
@@ -409,7 +427,7 @@ public final class SuperwallOptions: NSObject, Encodable {
     try networkEnvironment.encode(to: encoder)
     try logging.encode(to: encoder)
 
-    try container.encode(isExternalDataCollectionEnabled, forKey: .isExternalDataCollectionEnabled)
+    try container.encode(eventTrackingBehavior.description, forKey: .eventTrackingBehavior)
     try container.encode(localeIdentifier, forKey: .localeIdentifier)
     try container.encode(isGameControllerEnabled, forKey: .isGameControllerEnabled)
     try container.encode(storeKitVersion.description, forKey: .storeKitVersion)

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -310,15 +310,20 @@ public final class SuperwallOptions: NSObject, Encodable {
   /// Defaults to `true`.
   ///
   /// - Warning: Deprecated. Use ``eventTrackingBehavior`` instead.
-  ///   Setting this to `false` maps to ``EventTrackingBehavior/superwallOnly``;
-  ///   setting it back to `true` maps to ``EventTrackingBehavior/all``.
+  ///   Setting this to `false` maps to ``EventTrackingBehavior/superwallOnly`` unless the current
+  ///   value is already ``EventTrackingBehavior/none``, in which case `.none` is preserved.
+  ///   Setting it back to `true` maps to ``EventTrackingBehavior/all``.
   @available(*, deprecated, renamed: "eventTrackingBehavior")
   public var isExternalDataCollectionEnabled: Bool {
     get {
       return eventTrackingBehavior == .all
     }
     set {
-      eventTrackingBehavior = newValue ? .all : .superwallOnly
+      if newValue {
+        eventTrackingBehavior = .all
+      } else if eventTrackingBehavior != .none {
+        eventTrackingBehavior = .superwallOnly
+      }
     }
   }
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.15.4
+4.16.0
 """

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
@@ -301,6 +301,17 @@ final class PaywallMessageHandler: WebEventDelegate {
     await passMessageToWebView(base64Templates)
   }
 
+  func passEventTrackingBehaviorToWebView(_ behavior: EventTrackingBehavior) {
+    let event: [String: Any] = [
+      "event_name": "event_tracking_behavior",
+      "behavior": behavior.description
+    ]
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: [event]) else {
+      return
+    }
+    passMessageToWebView(jsonData.base64EncodedString())
+  }
+
   private func passMessageToWebView(_ base64String: String) {
     let messageScript = """
       window.paywall.accept64('\(base64String)');
@@ -372,6 +383,9 @@ final class PaywallMessageHandler: WebEventDelegate {
         paywallInfo: paywallInfo
       )
       await Superwall.shared.track(webViewLoad)
+
+      let behavior = await Superwall.shared.eventTrackingBehavior
+      await self.passEventTrackingBehaviorToWebView(behavior)
     }
 
     let htmlSubstitutions = paywall.htmlSubstitutions

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -83,7 +83,7 @@ actor PlacementsQueue {
   }
 
   private func trackingAllowed(from placement: Trackable) -> Bool {
-    switch Superwall.shared.options.eventTrackingBehavior {
+    switch configManager.options.eventTrackingBehavior {
     case .all:
       return true
     case .superwallOnly:

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -85,7 +85,7 @@ actor PlacementsQueue {
 
   func setTrackingBehavior(_ behavior: EventTrackingBehavior) {
     trackingBehavior = behavior
-    if behavior == .none {
+    if behavior != .all {
       elements.removeAll()
     }
   }

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -103,6 +103,11 @@ actor PlacementsQueue {
   }
 
   func flushInternal(depth: Int = 10) {
+    if configManager.options.eventTrackingBehavior == .none {
+      elements.removeAll()
+      return
+    }
+
     var eventsToSend: [JSON] = []
 
     var i = 0

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -76,22 +76,26 @@ actor PlacementsQueue {
     data: JSON,
     from placement: Trackable
   ) {
-    guard externalDataCollectionAllowed(from: placement) else {
+    guard trackingAllowed(from: placement) else {
       return
     }
     elements.append(data)
   }
 
-  private func externalDataCollectionAllowed(from placement: Trackable) -> Bool {
-    if Superwall.shared.options.isExternalDataCollectionEnabled {
+  private func trackingAllowed(from placement: Trackable) -> Bool {
+    switch Superwall.shared.options.eventTrackingBehavior {
+    case .all:
       return true
-    }
-    if placement is InternalSuperwallEvent.TriggerFire
-      || placement is InternalSuperwallEvent.UserAttributes
-      || placement is UserInitiatedPlacement.Track {
+    case .superwallOnly:
+      if placement is InternalSuperwallEvent.TriggerFire
+        || placement is InternalSuperwallEvent.UserAttributes
+        || placement is UserInitiatedPlacement.Track {
+        return false
+      }
+      return true
+    case .none:
       return false
     }
-    return true
   }
 
   func flushInternal(depth: Int = 10) {

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -98,12 +98,11 @@ actor PlacementsQueue {
     }
   }
 
-  func flushInternal(depth: Int = 10) {
-    if configManager.options.eventTrackingBehavior == .none {
-      elements.removeAll()
-      return
-    }
+  func clearBuffer() {
+    elements.removeAll()
+  }
 
+  func flushInternal(depth: Int = 10) {
     var eventsToSend: [JSON] = []
 
     var i = 0

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -99,6 +99,11 @@ actor PlacementsQueue {
   }
 
   func flushInternal(depth: Int = 10) {
+    if configManager.options.eventTrackingBehavior == .none {
+      elements.removeAll()
+      return
+    }
+
     var eventsToSend: [JSON] = []
 
     var i = 0

--- a/Sources/SuperwallKit/Storage/PlacementsQueue.swift
+++ b/Sources/SuperwallKit/Storage/PlacementsQueue.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by brian on 8/16/21.
 //
@@ -16,7 +16,8 @@ actor PlacementsQueue {
   private var elements: [JSON] = []
   private var timer: Timer?
   private unowned let network: Network
-  private unowned let configManager: ConfigManager
+  private var trackingBehavior: EventTrackingBehavior
+  private let timerInterval: Double
 
   @MainActor
   private var resignActiveObserver: AnyCancellable?
@@ -31,7 +32,14 @@ actor PlacementsQueue {
     configManager: ConfigManager
   ) {
     self.network = network
-    self.configManager = configManager
+    // Capture synchronously while configManager is guaranteed alive.
+    self.trackingBehavior = configManager.options.eventTrackingBehavior
+    switch configManager.options.networkEnvironment {
+    case .release:
+      self.timerInterval = 20.0
+    default:
+      self.timerInterval = 1.0
+    }
     Task { [weak self] in
       await self?.setupTimer()
       await self?.addObserver()
@@ -39,15 +47,8 @@ actor PlacementsQueue {
   }
 
   private func setupTimer() {
-    let timeInterval: Double
-    switch configManager.options.networkEnvironment {
-    case .release:
-      timeInterval = 20.0
-    default:
-      timeInterval = 1.0
-    }
     let timer = Timer(
-      timeInterval: timeInterval,
+      timeInterval: timerInterval,
       repeats: true
     ) { [weak self] _ in
       guard let self = self else {
@@ -82,8 +83,15 @@ actor PlacementsQueue {
     elements.append(data)
   }
 
+  func setTrackingBehavior(_ behavior: EventTrackingBehavior) {
+    trackingBehavior = behavior
+    if behavior == .none {
+      elements.removeAll()
+    }
+  }
+
   private func trackingAllowed(from placement: Trackable) -> Bool {
-    switch configManager.options.eventTrackingBehavior {
+    switch trackingBehavior {
     case .all:
       return true
     case .superwallOnly:
@@ -98,12 +106,8 @@ actor PlacementsQueue {
     }
   }
 
-  func clearBuffer() {
-    elements.removeAll()
-  }
-
   func flushInternal(depth: Int = 10) {
-    if configManager.options.eventTrackingBehavior == .none {
+    if trackingBehavior == .none {
       elements.removeAll()
       return
     }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -62,6 +62,29 @@ public final class Superwall: NSObject, ObservableObject {
     }
   }
 
+  /// Controls which events are sent to the Superwall servers at runtime.
+  ///
+  /// Defaults to ``EventTrackingBehavior/all``. Update this at any point after
+  /// ``configure(apiKey:purchaseController:options:completion:)-52tke`` to change event
+  /// collection dynamically — for example, toggling to ``EventTrackingBehavior/none``
+  /// after the user declines data collection in a GDPR consent flow.
+  ///
+  /// You can also set the initial value via ``SuperwallOptions/eventTrackingBehavior``
+  /// before calling `configure`.
+  public var eventTrackingBehavior: EventTrackingBehavior {
+    get {
+      return options.eventTrackingBehavior
+    }
+    set {
+      options.eventTrackingBehavior = newValue
+
+      let configAttributes = dependencyContainer.makeConfigAttributes()
+      Task {
+        await track(configAttributes)
+      }
+    }
+  }
+
   /// Defines the products to override on any paywall by product name.
   ///
   /// You can override one or more products of your choosing. For example, this is how you would override the first and third product on a paywall:

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -78,6 +78,12 @@ public final class Superwall: NSObject, ObservableObject {
     set {
       options.eventTrackingBehavior = newValue
 
+      if newValue == .none {
+        Task {
+          await dependencyContainer.placementsQueue.clearBuffer()
+        }
+      }
+
       let configAttributes = dependencyContainer.makeConfigAttributes()
       Task {
         await track(configAttributes)

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -82,6 +82,12 @@ public final class Superwall: NSObject, ObservableObject {
         await dependencyContainer.placementsQueue.setTrackingBehavior(newValue)
       }
 
+      let behavior = newValue
+      Task { @MainActor [weak self] in
+        self?.paywallViewController?.webView.messageHandler
+          .passEventTrackingBehaviorToWebView(behavior)
+      }
+
       let configAttributes = dependencyContainer.makeConfigAttributes()
       Task {
         await track(configAttributes)

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -78,10 +78,8 @@ public final class Superwall: NSObject, ObservableObject {
     set {
       options.eventTrackingBehavior = newValue
 
-      if newValue == .none {
-        Task {
-          await dependencyContainer.placementsQueue.clearBuffer()
-        }
+      Task {
+        await dependencyContainer.placementsQueue.setTrackingBehavior(newValue)
       }
 
       let configAttributes = dependencyContainer.makeConfigAttributes()

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -88,6 +88,13 @@ public final class Superwall: NSObject, ObservableObject {
           .passEventTrackingBehaviorToWebView(behavior)
       }
 
+      // When opting out entirely, don't emit the config-attributes event. It
+      // races the `setTrackingBehavior(.none)` Task above, so a flush could
+      // transmit it before the queue's opt-out takes effect.
+      if newValue == .none {
+        return
+      }
+
       let configAttributes = dependencyContainer.makeConfigAttributes()
       Task {
         await track(configAttributes)

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.15.4"
+  s.version      = "4.16.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		3CF2307C2CB994D00A35FADD /* LoadingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866F99509EDFBE8BAE10E575 /* LoadingModel.swift */; };
 		3DCE95BAC148CCC7E6E7F608 /* DeviceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */; };
 		3EA92DE86764CBAC557F8522 /* Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E41300E7467F017BCD5E5C /* Capabilities.swift */; };
+		3EE4C1C4EC45718C2EED34E5 /* EventTrackingBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8033AAF5549E30ACDA3EA /* EventTrackingBehavior.swift */; };
 		3F3774A066285BB0DFE61B61 /* JSONToDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09C238ADC0B019047FAB1DF /* JSONToDict.swift */; };
 		3F4BE7ECC80EEA757454F9B6 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124F219E38F8398A65A7EB32 /* DependencyContainer.swift */; };
 		3F6DD6FB62BDF53536FC4EF7 /* V4Migrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D685A5912892EF9C2931B1 /* V4Migrator.swift */; };
@@ -517,6 +518,7 @@
 		E9F80BA7BCAB71270E0E1CC1 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EAB177118BC78B02C3C00A /* AttributionFetcher.swift */; };
 		E9F892ABB9BDA85F4794E3CF /* SubscriptionStatusResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C15CF29C17FE1EE3BFDEDC /* SubscriptionStatusResolutionTests.swift */; };
 		EA50607230AA07B509E90E10 /* TestStoreUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7162E1E791297A3BF80B65A4 /* TestStoreUser.swift */; };
+		EA66951B1DF341C4F0448C9F /* PlacementsQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682AB10207309C439F64BC69 /* PlacementsQueueTests.swift */; };
 		EB1964816A8297CE133F96BF /* PurchaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E522F5BCABB3A95B97549E /* PurchaseError.swift */; };
 		EB6540A8E1ECC3548C5E6368 /* PaywallMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC653A44D9B40812BDDD94E7 /* PaywallMessage.swift */; };
 		ECA7E9C9898CAB24B56E7054 /* SK2PriceFormatRoundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC580BF1CC720ECBC4E68A28 /* SK2PriceFormatRoundingTests.swift */; };
@@ -807,6 +809,7 @@
 		67602AF9B2543CAD0B42F3CF /* CacheMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheMock.swift; sourceTree = "<group>"; };
 		67C4FC41FEE0B47EA402D738 /* LocalizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationConfig.swift; sourceTree = "<group>"; };
 		67D9C2B45E15025BF7D783AD /* zh_Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_Hans; path = zh_Hans.lproj/Localizable.strings; sourceTree = "<group>"; };
+		682AB10207309C439F64BC69 /* PlacementsQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacementsQueueTests.swift; sourceTree = "<group>"; };
 		68363EE16B2DE5C1C5361657 /* Enrichment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrichment.swift; sourceTree = "<group>"; };
 		6944763A0D07AFA102B023C5 /* PaywallManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallManagerLogicTests.swift; sourceTree = "<group>"; };
 		69A4D77D819DDB696834E1B7 /* UIViewController+AsyncPresent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AsyncPresent.swift"; sourceTree = "<group>"; };
@@ -911,6 +914,7 @@
 		93604964336C40E763A7BFAF /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		937CAD765EA00E4A0FC86037 /* V2ProductsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V2ProductsResponse.swift; sourceTree = "<group>"; };
 		938EB5121B1D9EA6B2EAE9EC /* Task+Retrying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Retrying.swift"; sourceTree = "<group>"; };
+		93D8033AAF5549E30ACDA3EA /* EventTrackingBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTrackingBehavior.swift; sourceTree = "<group>"; };
 		93FACE677755EAA3EA4E67A8 /* IntroOfferEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroOfferEligibility.swift; sourceTree = "<group>"; };
 		94125DB9AC8A2EA66F983EDA /* PresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResult.swift; sourceTree = "<group>"; };
 		9423D7BA0604D88E30161BFB /* PaywallCacheLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheLogic.swift; sourceTree = "<group>"; };
@@ -2481,6 +2485,7 @@
 		A1EF6DDE57A911501DFB2B4D /* Storage */ = {
 			isa = PBXGroup;
 			children = (
+				682AB10207309C439F64BC69 /* PlacementsQueueTests.swift */,
 				6D1887F247BF6F770122F257 /* StorageMock.swift */,
 				787764B249892BBCA1088235 /* StorageTests.swift */,
 				0E582EAD2A75C1D7A72F2E52 /* Cache */,
@@ -2941,6 +2946,7 @@
 			isa = PBXGroup;
 			children = (
 				23307BBFD80385233DDD4C43 /* AssetResource.swift */,
+				93D8033AAF5549E30ACDA3EA /* EventTrackingBehavior.swift */,
 				B1A64CCBCB23CC1715DF79AC /* PaywallOptions.swift */,
 				CFDA311A030FDFC45AEE248A /* SuperwallOptions.swift */,
 			);
@@ -3289,6 +3295,7 @@
 				5F1F480AA12C8D17B179D96B /* PaywallViewControllerMock.swift in Sources */,
 				ED246150DA2747AA42D6009C /* PermissionStatusTests.swift in Sources */,
 				4A4E5413A8753AFB624D325D /* PermissionTypeTests.swift in Sources */,
+				EA66951B1DF341C4F0448C9F /* PlacementsQueueTests.swift in Sources */,
 				A3A0961A4A230C10B8896400 /* PopupTransitionTests.swift in Sources */,
 				3BE562844FD54486450CE6BB /* PresentPaywallOperatorTests.swift in Sources */,
 				3652D5EE4C172D623BDEE7E4 /* PresentationIdTests.swift in Sources */,
@@ -3439,6 +3446,7 @@
 				DEF83BEF1ED06921BD55F55A /* EvaluationContext.swift in Sources */,
 				2653909358966BE9AC9894F1 /* EvaluationResult.swift in Sources */,
 				35597883CB038DBEE63E162B /* EventData.swift in Sources */,
+				3EE4C1C4EC45718C2EED34E5 /* EventTrackingBehavior.swift in Sources */,
 				F297363F2C4BFEE9D051D684 /* EventsRequest.swift in Sources */,
 				5FB78EB52A12BA704AD3AE31 /* EventsResponse.swift in Sources */,
 				412C74624BB8933162DAAC5F /* Experiment.swift in Sources */,

--- a/Tests/SuperwallKitTests/Network/NetworkMock.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkMock.swift
@@ -11,6 +11,7 @@ import Combine
 
 final class NetworkMock: Network {
   var sentSessionEvents: SessionEventsRequest?
+  var sentEvents: [EventsRequest] = []
   var getConfigCalled = false
   var assignmentsConfirmed = false
   var assignments: [PostbackAssignment] = []
@@ -28,6 +29,10 @@ final class NetworkMock: Network {
   var pollRedemptionResultCallCount = 0
   var onRedeemEntitlements: (() -> Void)?
   var onPollRedemptionResult: (() -> Void)?
+
+  override func sendEvents(events: EventsRequest) async {
+    sentEvents.append(events)
+  }
 
   override func sendSessionEvents(_ session: SessionEventsRequest) async {
     sentSessionEvents = session

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -170,6 +170,22 @@ struct PlacementsQueueTests {
     #expect(setup.network.sentEvents.isEmpty)
   }
 
+  @Test
+  func none_discardsAlreadyBufferedEvents() async throws {
+    // Events enqueued while .all, then behavior switches to .none before flush.
+    let setup = makeQueue(behavior: .all)
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+
+    // Simulate runtime opt-out before the timer fires.
+    setup.configManager.options.eventTrackingBehavior = .none
+
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
   // MARK: - Deprecated isExternalDataCollectionEnabled backwards compatibility
 
   @Test

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -1,0 +1,255 @@
+//
+//  PlacementsQueueTests.swift
+//
+//
+//  Created by Yusuf Tör on 22/06/2026.
+//
+// swiftlint:disable all
+
+import Testing
+import Foundation
+@testable import SuperwallKit
+
+@Suite(.serialized)
+struct PlacementsQueueTests {
+  private let stubJSON = JSON(["event": "test"])
+
+  // MARK: - EventTrackingBehavior.all
+
+  @Test
+  func all_allowsUserInitiatedTrack() async throws {
+    let setup = makeQueue(behavior: .all)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: UserInitiatedPlacement.Track(
+        rawName: "test",
+        canImplicitlyTriggerPaywall: false,
+        isFeatureGatable: false
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
+  @Test
+  func all_allowsTriggerFire() async throws {
+    let setup = makeQueue(behavior: .all)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.TriggerFire(
+        triggerResult: .noAudienceMatch([]),
+        triggerName: "test"
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
+  @Test
+  func all_allowsUserAttributes() async throws {
+    let setup = makeQueue(behavior: .all)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.UserAttributes(appInstalledAtString: "now")
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
+  @Test
+  func all_allowsInternalEvent() async throws {
+    let setup = makeQueue(behavior: .all)
+
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
+  // MARK: - EventTrackingBehavior.superwallOnly
+
+  @Test
+  func superwallOnly_blocksUserInitiatedTrack() async throws {
+    let setup = makeQueue(behavior: .superwallOnly)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: UserInitiatedPlacement.Track(
+        rawName: "test",
+        canImplicitlyTriggerPaywall: false,
+        isFeatureGatable: false
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  @Test
+  func superwallOnly_blocksTriggerFire() async throws {
+    let setup = makeQueue(behavior: .superwallOnly)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.TriggerFire(
+        triggerResult: .noAudienceMatch([]),
+        triggerName: "test"
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  @Test
+  func superwallOnly_blocksUserAttributes() async throws {
+    let setup = makeQueue(behavior: .superwallOnly)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.UserAttributes(appInstalledAtString: "now")
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  @Test
+  func superwallOnly_allowsInternalEvent() async throws {
+    let setup = makeQueue(behavior: .superwallOnly)
+
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
+  // MARK: - EventTrackingBehavior.none
+
+  @Test
+  func none_blocksAllEvents() async throws {
+    let setup = makeQueue(behavior: .none)
+
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.UserAttributes(appInstalledAtString: "now")
+    )
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: UserInitiatedPlacement.Track(
+        rawName: "test",
+        canImplicitlyTriggerPaywall: false,
+        isFeatureGatable: false
+      )
+    )
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.TriggerFire(
+        triggerResult: .noAudienceMatch([]),
+        triggerName: "test"
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  // MARK: - Deprecated isExternalDataCollectionEnabled backwards compatibility
+
+  @Test
+  func deprecatedFalse_mapsToSuperwallOnly() {
+    let options = SuperwallOptions()
+    options.isExternalDataCollectionEnabled = false
+    #expect(options.eventTrackingBehavior == .superwallOnly)
+  }
+
+  @Test
+  func deprecatedTrue_mapsToAll() {
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .superwallOnly
+    options.isExternalDataCollectionEnabled = true
+    #expect(options.eventTrackingBehavior == .all)
+  }
+
+  @Test
+  func deprecatedGetter_trueWhenAll() {
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .all
+    #expect(options.isExternalDataCollectionEnabled == true)
+  }
+
+  @Test
+  func deprecatedGetter_falseWhenSuperwallOnly() {
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .superwallOnly
+    #expect(options.isExternalDataCollectionEnabled == false)
+  }
+
+  @Test
+  func deprecatedGetter_falseWhenNone() {
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .none
+    #expect(options.isExternalDataCollectionEnabled == false)
+  }
+
+  // MARK: - Runtime Superwall.shared property
+
+  @Test
+  func runtimeSetter_updatesOptions() {
+    Superwall.shared.eventTrackingBehavior = .superwallOnly
+    #expect(Superwall.shared.options.eventTrackingBehavior == .superwallOnly)
+
+    Superwall.shared.eventTrackingBehavior = .all
+    #expect(Superwall.shared.options.eventTrackingBehavior == .all)
+  }
+
+  // MARK: - Helpers
+
+  private struct QueueSetup {
+    let queue: PlacementsQueue
+    let network: NetworkMock
+    let configManager: ConfigManager
+    let dependencyContainer: DependencyContainer
+  }
+
+  private func makeQueue(behavior: EventTrackingBehavior) -> QueueSetup {
+    Superwall.shared.options.eventTrackingBehavior = behavior
+
+    let dependencyContainer = DependencyContainer()
+    let network = NetworkMock(options: SuperwallOptions(), factory: dependencyContainer)
+    let configManager = ConfigManager(
+      options: SuperwallOptions(),
+      storeKitManager: dependencyContainer.storeKitManager,
+      storage: dependencyContainer.storage,
+      network: network,
+      paywallManager: dependencyContainer.paywallManager,
+      deviceHelper: dependencyContainer.deviceHelper,
+      entitlementsInfo: dependencyContainer.entitlementsInfo,
+      webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
+      factory: dependencyContainer
+    )
+    let queue = PlacementsQueue(network: network, configManager: configManager)
+    return QueueSetup(
+      queue: queue,
+      network: network,
+      configManager: configManager,
+      dependencyContainer: dependencyContainer
+    )
+  }
+}

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -236,7 +236,7 @@ struct PlacementsQueueTests {
   private struct QueueSetup {
     let queue: PlacementsQueue
     let network: NetworkMock
-    // Keep configManager and dependencyContainer alive so unowned refs inside the queue remain valid.
+    // Keep network and its dependencyContainer alive; network is the only unowned ref the queue holds.
     let configManager: ConfigManager
     let dependencyContainer: DependencyContainer
   }

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -171,15 +171,12 @@ struct PlacementsQueueTests {
   }
 
   @Test
-  func none_discardsAlreadyBufferedEvents() async throws {
-    // Events enqueued while .all, then behavior switches to .none before flush.
+  func clearBuffer_discardsAllBufferedEvents() async throws {
     let setup = makeQueue(behavior: .all)
     await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
     await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
 
-    // Simulate runtime opt-out before the timer fires.
-    setup.configManager.options.eventTrackingBehavior = .none
-
+    await setup.queue.clearBuffer()
     await setup.queue.flushInternal()
     try await Task.sleep(nanoseconds: 100_000_000)
 

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -188,6 +188,14 @@ struct PlacementsQueueTests {
   }
 
   @Test
+  func deprecatedFalse_preservesNone() {
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .none
+    options.isExternalDataCollectionEnabled = false
+    #expect(options.eventTrackingBehavior == .none)
+  }
+
+  @Test
   func deprecatedGetter_trueWhenAll() {
     let options = SuperwallOptions()
     options.eventTrackingBehavior = .all
@@ -212,11 +220,12 @@ struct PlacementsQueueTests {
 
   @Test
   func runtimeSetter_updatesOptions() {
-    Superwall.shared.eventTrackingBehavior = .superwallOnly
-    #expect(Superwall.shared.options.eventTrackingBehavior == .superwallOnly)
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = .superwallOnly
+    #expect(options.eventTrackingBehavior == .superwallOnly)
 
-    Superwall.shared.eventTrackingBehavior = .all
-    #expect(Superwall.shared.options.eventTrackingBehavior == .all)
+    options.eventTrackingBehavior = .all
+    #expect(options.eventTrackingBehavior == .all)
   }
 
   // MARK: - Helpers
@@ -229,12 +238,13 @@ struct PlacementsQueueTests {
   }
 
   private func makeQueue(behavior: EventTrackingBehavior) -> QueueSetup {
-    Superwall.shared.options.eventTrackingBehavior = behavior
+    let options = SuperwallOptions()
+    options.eventTrackingBehavior = behavior
 
     let dependencyContainer = DependencyContainer()
-    let network = NetworkMock(options: SuperwallOptions(), factory: dependencyContainer)
+    let network = NetworkMock(options: options, factory: dependencyContainer)
     let configManager = ConfigManager(
-      options: SuperwallOptions(),
+      options: options,
       storeKitManager: dependencyContainer.storeKitManager,
       storage: dependencyContainer.storage,
       network: network,

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -232,18 +232,6 @@ struct PlacementsQueueTests {
     #expect(options.isExternalDataCollectionEnabled == false)
   }
 
-  // MARK: - Runtime Superwall.shared property
-
-  @Test
-  func runtimeSetter_updatesOptions() {
-    let options = SuperwallOptions()
-    options.eventTrackingBehavior = .superwallOnly
-    #expect(options.eventTrackingBehavior == .superwallOnly)
-
-    options.eventTrackingBehavior = .all
-    #expect(options.eventTrackingBehavior == .all)
-  }
-
   // MARK: - Helpers
 
   private struct QueueSetup {

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -171,28 +171,14 @@ struct PlacementsQueueTests {
   }
 
   @Test
-  func clearBuffer_discardsAllBufferedEvents() async throws {
+  func none_setTrackingBehaviorDiscardsBufferAndBlocksFlush() async throws {
+    // Covers both the eager clear and the flush-time guard in one shot.
     let setup = makeQueue(behavior: .all)
     await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
     await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
 
-    await setup.queue.clearBuffer()
-    await setup.queue.flushInternal()
-    try await Task.sleep(nanoseconds: 100_000_000)
-
-    #expect(setup.network.sentEvents.isEmpty)
-  }
-
-  @Test
-  func none_flushAfterOptOutSendsNothing() async throws {
-    // Simulates the race where flushInternal runs after the behavior is switched
-    // to .none but before clearBuffer() has had a turn on the actor.
-    let setup = makeQueue(behavior: .all)
-    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
-    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
-
-    setup.configManager.options.eventTrackingBehavior = .none
-
+    // Simulate the runtime opt-out (mirrors what Superwall.shared setter does).
+    await setup.queue.setTrackingBehavior(.none)
     await setup.queue.flushInternal()
     try await Task.sleep(nanoseconds: 100_000_000)
 
@@ -250,6 +236,7 @@ struct PlacementsQueueTests {
   private struct QueueSetup {
     let queue: PlacementsQueue
     let network: NetworkMock
+    // Keep configManager and dependencyContainer alive so unowned refs inside the queue remain valid.
     let configManager: ConfigManager
     let dependencyContainer: DependencyContainer
   }

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -183,6 +183,22 @@ struct PlacementsQueueTests {
     #expect(setup.network.sentEvents.isEmpty)
   }
 
+  @Test
+  func none_flushAfterOptOutSendsNothing() async throws {
+    // Simulates the race where flushInternal runs after the behavior is switched
+    // to .none but before clearBuffer() has had a turn on the actor.
+    let setup = makeQueue(behavior: .all)
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+
+    setup.configManager.options.eventTrackingBehavior = .none
+
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
   // MARK: - Deprecated isExternalDataCollectionEnabled backwards compatibility
 
   @Test

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -138,6 +138,27 @@ struct PlacementsQueueTests {
     #expect(setup.network.sentEvents.count == 1)
   }
 
+  @Test
+  func superwallOnly_allowsConfigAttributes() async throws {
+    // ConfigAttributes is a Superwall-internal event, so it is permitted under
+    // .superwallOnly — which is why the `eventTrackingBehavior` setter still
+    // tracks it for .superwallOnly and only skips it for .none.
+    let setup = makeQueue(behavior: .superwallOnly)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.ConfigAttributes(
+        options: SuperwallOptions(),
+        hasExternalPurchaseController: false,
+        hasDelegate: false
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.count == 1)
+  }
+
   // MARK: - EventTrackingBehavior.none
 
   @Test
@@ -162,6 +183,27 @@ struct PlacementsQueueTests {
       from: InternalSuperwallEvent.TriggerFire(
         triggerResult: .noAudienceMatch([]),
         triggerName: "test"
+      )
+    )
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  @Test
+  func none_blocksConfigAttributes() async throws {
+    // Backs up the `eventTrackingBehavior` setter's early return for .none: even
+    // if a config-attributes event reached the queue (losing the Task-ordering
+    // race), the queue still blocks it once the behavior is .none.
+    let setup = makeQueue(behavior: .none)
+
+    await setup.queue.enqueue(
+      data: stubJSON,
+      from: InternalSuperwallEvent.ConfigAttributes(
+        options: SuperwallOptions(),
+        hasExternalPurchaseController: false,
+        hasDelegate: false
       )
     )
     await setup.queue.flushInternal()

--- a/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
+++ b/Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift
@@ -171,6 +171,19 @@ struct PlacementsQueueTests {
   }
 
   @Test
+  func superwallOnly_setTrackingBehaviorDiscardsBuffer() async throws {
+    let setup = makeQueue(behavior: .all)
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+    await setup.queue.enqueue(data: stubJSON, from: InternalSuperwallEvent.AppOpen())
+
+    await setup.queue.setTrackingBehavior(.superwallOnly)
+    await setup.queue.flushInternal()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    #expect(setup.network.sentEvents.isEmpty)
+  }
+
+  @Test
   func none_setTrackingBehaviorDiscardsBufferAndBlocksFlush() async throws {
     // Covers both the eager clear and the flush-time guard in one shot.
     let setup = makeQueue(behavior: .all)


### PR DESCRIPTION
## Summary

- Adds new `EventTrackingBehavior` enum with `.all` / `.superwallOnly` / `.none` cases to replace the deprecated `isExternalDataCollectionEnabled` bool
- The behavior is configurable at SDK init time via `SuperwallOptions.eventTrackingBehavior` and at runtime via `Superwall.shared.eventTrackingBehavior` (same pattern as `logLevel`)
- Deprecates `SuperwallOptions.isExternalDataCollectionEnabled` with a backwards-compatible computed property: `false` → `.superwallOnly`, `true` → `.all`
- `.superwallOnly` preserves existing behaviour (blocks user-initiated `.track()` calls, trigger fires, and user-attribute updates while letting internal SDK events through)
- `.none` blocks all events — equivalent to never calling `Superwall.configure` from an event-tracking perspective, intended for GDPR consent flows

## Changelog entry

Added `EventTrackingBehavior` enum and `SuperwallOptions.eventTrackingBehavior` property. Deprecated `isExternalDataCollectionEnabled`.

## Test plan

- [x] 15 new unit tests in `PlacementsQueueTests` covering all three enum cases and deprecated API backwards-compatibility
- [x] All 15 new tests pass
- [x] Full test suite passes (exit code 0)
- [x] SwiftLint: 0 violations
- [ ] Demo project builds and runs on iOS
- [ ] Demo project builds and runs on Mac Catalyst
- [ ] Demo project builds and runs on visionOS
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `EventTrackingBehavior` (`.all` / `.superwallOnly` / `.none`) to replace the deprecated `isExternalDataCollectionEnabled` bool, making event suppression more granular and GDPR-friendly. The runtime property `Superwall.shared.eventTrackingBehavior` follows the same pattern as `logLevel`.

- **`PlacementsQueue`** drops the `configManager` dependency in favour of a captured `trackingBehavior` field plus a new `setTrackingBehavior` method; buffer clearing on behaviour transitions and the `flushInternal` guard address the previously-flagged data-leak scenarios.
- **`SuperwallOptions`** migrates the `CodingKey` from the old Bool field to the new string-encoded enum value, which changes the on-wire serialisation format; the deprecated computed property preserves `.none` when the bool is written `false`.
- **`Superwall.eventTrackingBehavior` setter** (new) dispatches `setTrackingBehavior` and `track(configAttributes)` as independent unstructured Tasks, creating a window where a config-attributes event may race through before the queue applies the `.none` gate — directly affecting the stated GDPR use case.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the understanding that setting `eventTrackingBehavior = .none` may still transmit one config-attributes event on the transition due to the async task ordering.

The core logic is sound and the previously-flagged buffer-leak issues are well-addressed. The outstanding concern is that the `Superwall.eventTrackingBehavior` setter fires `track(configAttributes)` via an unstructured Task that races against `setTrackingBehavior(.none)` on the PlacementsQueue actor. For users setting `.none` in a GDPR consent flow, this can cause one internal event to slip through on the exact transition. All other paths are correctly gated.

Sources/SuperwallKit/Superwall.swift — the `eventTrackingBehavior` setter's unconditional `track(configAttributes)` Task needs a guard for `newValue == .none`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Storage/PlacementsQueue.swift | Replaces injected configManager dependency with a captured `trackingBehavior` and a new `setTrackingBehavior` method; adds `flushInternal` guard and buffer-clearing on behavior changes. Previous thread issues (DI bypass, buffer leak on `.superwallOnly`, flush-time bypass for `.none`) are all addressed. |
| Sources/SuperwallKit/Superwall.swift | Adds `eventTrackingBehavior` runtime property mirroring the `logLevel` pattern; setter has a Task-ordering race where `track(configAttributes)` may fire before `setTrackingBehavior(.none)` updates the queue, leaking one event on GDPR opt-out. |
| Sources/SuperwallKit/Config/Options/EventTrackingBehavior.swift | New `@objc`-bridged enum with `.all`, `.superwallOnly`, `.none` cases; well-documented and Sendable/Encodable conformances look correct. |
| Sources/SuperwallKit/Config/Options/SuperwallOptions.swift | Adds `eventTrackingBehavior` property and deprecates `isExternalDataCollectionEnabled` with backwards-compatible computed property; CodingKey migration from the old Bool key to the new string-encoded enum key changes the on-wire format. |
| Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift | Adds `passEventTrackingBehaviorToWebView` to push the current behavior into the web paywall after load; called safely via `@MainActor` task from the setter and from the existing async `didLoadWebView` utility task. |
| Tests/SuperwallKitTests/Storage/PlacementsQueueTests.swift | 15 new unit tests cover all three enum cases, runtime behavior-switching, and deprecated API backwards-compatibility; well-structured with a shared `makeQueue` helper. |
| Tests/SuperwallKitTests/Network/NetworkMock.swift | Adds `sentEvents` accumulator and `sendEvents` override to make `PlacementsQueue` unit tests possible without network calls. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant Superwall
    participant PlacementsQueue
    participant Network

    App->>Superwall: "eventTrackingBehavior = .none"
    Superwall->>Superwall: "options.eventTrackingBehavior = .none (sync)"
    Superwall-->>PlacementsQueue: Task A: setTrackingBehavior(.none)
    Superwall-->>Superwall: Task C: track(configAttributes)
    Note over PlacementsQueue,Superwall: Race: Task C may reach enqueue before Task A updates trackingBehavior
    alt Task A wins (expected)
        PlacementsQueue->>PlacementsQueue: "trackingBehavior = .none, elements.removeAll()"
        Superwall->>PlacementsQueue: enqueue(configAttributes) — blocked ✓
    else Task C wins (race)
        Superwall->>PlacementsQueue: enqueue(configAttributes) — allowed ✗
        PlacementsQueue->>Network: sendEvents (leaks after opt-out)
        PlacementsQueue->>PlacementsQueue: "trackingBehavior = .none (too late)"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant Superwall
    participant PlacementsQueue
    participant Network

    App->>Superwall: "eventTrackingBehavior = .none"
    Superwall->>Superwall: "options.eventTrackingBehavior = .none (sync)"
    Superwall-->>PlacementsQueue: Task A: setTrackingBehavior(.none)
    Superwall-->>Superwall: Task C: track(configAttributes)
    Note over PlacementsQueue,Superwall: Race: Task C may reach enqueue before Task A updates trackingBehavior
    alt Task A wins (expected)
        PlacementsQueue->>PlacementsQueue: "trackingBehavior = .none, elements.removeAll()"
        Superwall->>PlacementsQueue: enqueue(configAttributes) — blocked ✓
    else Task C wins (race)
        Superwall->>PlacementsQueue: enqueue(configAttributes) — allowed ✗
        PlacementsQueue->>Network: sendEvents (leaks after opt-out)
        PlacementsQueue->>PlacementsQueue: "trackingBehavior = .none (too late)"
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `Sources/SuperwallKit/Storage/PlacementsQueue.swift`, line 101-119 ([link](https://github.com/superwall/superwall-ios/blob/c4c3d6bbe2934e7b60fac713c115fd99391bb727/Sources/SuperwallKit/Storage/PlacementsQueue.swift#L101-L119)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Already-queued events bypass the `.none` gate**

   When `eventTrackingBehavior` is set to `.none` at runtime (e.g., after the user declines a GDPR consent prompt), the `trackingAllowed` gate prevents *new* events from entering `elements`, but events already buffered in `elements` are still sent on the next timer tick or `willResignActive` flush. For the stated GDPR consent-flow use case, this means up to `maxEventCount` (50) previously-buffered events can be transmitted after the user has opted out. `flushInternal` should skip or discard the buffer when the current behavior is `.none`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/SuperwallKit/Storage/PlacementsQueue.swift
   Line: 101-119

   Comment:
   **Already-queued events bypass the `.none` gate**

   When `eventTrackingBehavior` is set to `.none` at runtime (e.g., after the user declines a GDPR consent prompt), the `trackingAllowed` gate prevents *new* events from entering `elements`, but events already buffered in `elements` are still sent on the next timer tick or `willResignActive` flush. For the stated GDPR consent-flow use case, this means up to `maxEventCount` (50) previously-buffered events can be transmitted after the user has opted out. `flushInternal` should skip or discard the buffer when the current behavior is `.none`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `Sources/SuperwallKit/Storage/PlacementsQueue.swift`, line 101-119 ([link](https://github.com/superwall/superwall-ios/blob/dcfa0b0fd922d291b5b82c6398269e40a2d608a0/Sources/SuperwallKit/Storage/PlacementsQueue.swift#L101-L119)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Buffered events flushed after `.none` is set**

   `flushInternal` drains `elements` without checking the current `eventTrackingBehavior`. When a user declines consent and the behavior is switched to `.none` at runtime, any events already queued in `elements` (up to `maxEventCount` = 50) are sent on the very next timer tick or `willResignActive` notification — exactly the outcome the GDPR opt-out feature is meant to prevent. Adding a guard at the top of `flushInternal` (or discarding `elements` on the `.none` path) would close this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/SuperwallKit/Storage/PlacementsQueue.swift
   Line: 101-119

   Comment:
   **Buffered events flushed after `.none` is set**

   `flushInternal` drains `elements` without checking the current `eventTrackingBehavior`. When a user declines consent and the behavior is switched to `.none` at runtime, any events already queued in `elements` (up to `maxEventCount` = 50) are sent on the very next timer tick or `willResignActive` notification — exactly the outcome the GDPR opt-out feature is meant to prevent. Adding a guard at the top of `flushInternal` (or discarding `elements` on the `.none` path) would close this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/SuperwallKit/Superwall.swift:91-95
**`track(configAttributes)` may bypass the `.none` opt-out due to a Task ordering race**

When `eventTrackingBehavior` is set to `.none`, `options.eventTrackingBehavior` is updated synchronously but `placementsQueue.setTrackingBehavior(.none)` (Task A) and `track(configAttributes)` (Task C) are both dispatched as independent unstructured Tasks. If Task C reaches `PlacementsQueue.enqueue` before Task A updates the actor's local `trackingBehavior`, the config-attributes event is sent — defeating the GDPR opt-out guarantee. Since `track(configAttributes)` traverses more async hops than `setTrackingBehavior`, the window is narrow but real. The simplest fix is to skip the `track(configAttributes)` call when `newValue == .none`.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Send event\_tracking\_behavior to paywall ..."](https://github.com/superwall/superwall-ios/commit/04704cbd8cf68af858401a3729e5bab23b01a75e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39057748)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->