### PR TITLE
Fix free trial shown for upgrades within an active subscription group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Fixes a crash due to concurrent calls to `preloadAllPaywalls`.
 - Fixes an intro offer eligibility mismatch between the paywall and the payment sheet when upgrading/crossgrading/downgrading.
-- Fixes StoreKit 2 introductory offer eligibility being cached for the lifetime of the app process. Eligibility is now re-queried from StoreKit on each check, so it stays correct after the user redeems a trial, after `reset()`, and after user identity switches.
 
 ## 4.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes a crash due to concurrent calls to `preloadAllPaywalls`.
+- Fixes a free trial being shown for a product when the user already has an active subscription in the same subscription group. Apple does not apply introductory offers to upgrades, crossgrades, or downgrades, so the trial was advertised but never granted on purchase. Trial availability now also requires that there's no active App Store subscription in the product's subscription group.
+- Fixes StoreKit 2 introductory offer eligibility being cached for the lifetime of the app process. Eligibility is now re-queried from StoreKit on each check, so it stays correct after the user redeems a trial, after `reset()`, and after user identity switches.
 
 ## 4.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes a crash due to concurrent calls to `preloadAllPaywalls`.
-- Fixes a free trial being shown for a product when the user already has an active subscription in the same subscription group. Apple does not apply introductory offers to upgrades, crossgrades, or downgrades, so the trial was advertised but never granted on purchase. Trial availability now also requires that there's no active App Store subscription in the product's subscription group.
+- Fixes an intro offer eligibility mismatch between the paywall and the payment sheet when upgrading/crossgrading/downgrading.
 - Fixes StoreKit 2 introductory offer eligibility being cached for the lifetime of the app process. Eligibility is now re-queried from StoreKit on each check, so it stays correct after the user redeems a trial, after `reset()`, and after user identity switches.
 
 ## 4.15.3

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -241,12 +241,10 @@ actor ReceiptManager {
     }
 
     // Record which subscription groups the user has an *active* subscription in, so
-    // `isFreeTrialAvailable` can suppress trials on upgrades/crossgrades. Computed from
-    // the fetched products (which carry the group ID on both StoreKit 1 and 2) rather
-    // than the device snapshot, whose `subscriptions` array is empty on StoreKit 1.
+    // `isFreeTrialAvailable` can suppress trials on upgrades/crossgrades.
     activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(
-      forActivePurchasesIn: onDeviceSnapshot.purchases,
-      amongProducts: storeProducts
+      from: onDeviceSnapshot,
+      storeProducts: storeProducts
     )
 
     await manager.loadIntroOfferEligibility(forProducts: storeProducts)
@@ -361,18 +359,24 @@ actor ReceiptManager {
   }
 }
 
-/// Subscription group IDs that have at least one active purchase among `storeProducts`.
-/// File-scoped (it needs no actor state) so it doesn't count toward the actor body length.
-private func computeActiveSubscriptionGroupIds(
-  forActivePurchasesIn purchases: Set<Purchase>,
-  amongProducts storeProducts: Set<StoreProduct>
+/// Subscription group IDs the user currently has an active subscription in, unioned from two
+/// sources so none is dropped: snapshot transactions (StoreKit 2 carries the group ID, so this
+/// survives a delisted product) and active purchases' fetched-product groups (StoreKit 1's only
+/// source). File-scoped so it doesn't count toward the actor body length.
+func computeActiveSubscriptionGroupIds(
+  from snapshot: PurchaseSnapshot,
+  storeProducts: Set<StoreProduct>
 ) -> Set<String> {
-  let activeProductIds = Set(purchases.filter { $0.isActive }.map { $0.id })
-  return Set(
-    storeProducts
-      .filter { activeProductIds.contains($0.productIdentifier) }
-      .compactMap { $0.subscriptionGroupIdentifier }
-  )
+  let transactionGroupIds = snapshot.customerInfo.subscriptions
+    .filter { $0.isActive }
+    .compactMap { $0.subscriptionGroupId }
+
+  let activeProductIds = Set(snapshot.purchases.filter { $0.isActive }.map { $0.id })
+  let productGroupIds = storeProducts
+    .filter { activeProductIds.contains($0.productIdentifier) }
+    .compactMap { $0.subscriptionGroupIdentifier }
+
+  return Set(transactionGroupIds).union(productGroupIds)
 }
 
 final class ReceiptRefreshDelegateWrapper: NSObject, SKRequestDelegate {

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -30,6 +30,11 @@ actor ReceiptManager {
   private let delegateWrapper: ReceiptRefreshDelegateWrapper
   private unowned let factory: Factory
   private unowned let storage: Storage
+  /// Subscription group IDs the user currently has an active subscription in. Computed
+  /// during `loadPurchasedProducts` from the active purchases and their fetched products,
+  /// so it works for both StoreKit 1 and StoreKit 2. Used to suppress free trials on
+  /// upgrades/crossgrades/downgrades, which Apple won't apply an intro offer to.
+  private var activeSubscriptionGroupIds: Set<String>
   static var appTransactionId: String?
   static var appId: UInt64?
   /// Set from `AppTransaction.shared` when available (iOS 16+).
@@ -43,13 +48,15 @@ actor ReceiptManager {
     receiptManager: ReceiptManagerType? = nil, // For testing
     receiptDelegate: ReceiptDelegate?,
     factory: Factory,
-    storage: Storage
+    storage: Storage,
+    activeSubscriptionGroupIds: Set<String> = [] // For testing
   ) {
     self.storeKitVersion = storeKitVersion
     self.shouldBypassAppTransactionCheck = shouldBypassAppTransactionCheck
     self.productsManager = productsManager
     self.factory = factory
     self.storage = storage
+    self.activeSubscriptionGroupIds = activeSubscriptionGroupIds
 
     if let receiptManager = receiptManager {
       self.manager = receiptManager
@@ -233,6 +240,15 @@ actor ReceiptManager {
       return
     }
 
+    // Record which subscription groups the user has an *active* subscription in, so
+    // `isFreeTrialAvailable` can suppress trials on upgrades/crossgrades. Computed from
+    // the fetched products (which carry the group ID on both StoreKit 1 and 2) rather
+    // than the device snapshot, whose `subscriptions` array is empty on StoreKit 1.
+    activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(
+      forActivePurchasesIn: onDeviceSnapshot.purchases,
+      amongProducts: storeProducts
+    )
+
     await manager.loadIntroOfferEligibility(forProducts: storeProducts)
   }
 
@@ -246,8 +262,8 @@ actor ReceiptManager {
   /// subscription in the same subscription group, purchasing a product in that group is a
   /// product change and no trial is granted, even though `isEligibleForIntroOffer` is `true`.
   ///
-  /// So we also require that there's no active App Store subscription in the product's group,
-  /// to avoid advertising a free trial that Apple won't honor. (Once the existing subscription
+  /// So we also require that there's no active subscription in the product's group, to
+  /// avoid advertising a free trial that Apple won't honor. (Once the existing subscription
   /// lapses, a fresh purchase is a new subscription and the trial applies again.)
   func isFreeTrialAvailable(for storeProduct: StoreProduct) async -> Bool {
     let isEligibleForIntroOffer = await manager.isEligibleForIntroOffer(storeProduct)
@@ -261,13 +277,10 @@ actor ReceiptManager {
       return true
     }
 
-    let deviceSubscriptions = storage.get(LatestDeviceCustomerInfo.self)?.subscriptions ?? []
-    let hasActiveSubscriptionInGroup = deviceSubscriptions.contains { subscription in
-      subscription.store == .appStore
-        && subscription.isActive
-        && subscription.subscriptionGroupId == subscriptionGroupId
-    }
-    return !hasActiveSubscriptionInGroup
+    // `activeSubscriptionGroupIds` is populated in `loadPurchasedProducts`, which always
+    // completes before a paywall opens (config is only marked retrieved after it runs,
+    // and presentation waits for config), so this reflects current subscription state.
+    return !activeSubscriptionGroupIds.contains(subscriptionGroupId)
   }
 
   /// Determines whether the user is subscribed to the given product id.
@@ -346,6 +359,20 @@ actor ReceiptManager {
 
     request.cancel()
   }
+}
+
+/// Subscription group IDs that have at least one active purchase among `storeProducts`.
+/// File-scoped (it needs no actor state) so it doesn't count toward the actor body length.
+private func computeActiveSubscriptionGroupIds(
+  forActivePurchasesIn purchases: Set<Purchase>,
+  amongProducts storeProducts: Set<StoreProduct>
+) -> Set<String> {
+  let activeProductIds = Set(purchases.filter { $0.isActive }.map { $0.id })
+  return Set(
+    storeProducts
+      .filter { activeProductIds.contains($0.productIdentifier) }
+      .compactMap { $0.subscriptionGroupIdentifier }
+  )
 }
 
 final class ReceiptRefreshDelegateWrapper: NSObject, SKRequestDelegate {

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -230,11 +230,6 @@ actor ReceiptManager {
 
     await receiptDelegate?.syncSubscriptionStatus(purchases: onDeviceSnapshot.purchases)
 
-    // Refresh from this load's snapshot first, so the active-group state never describes a
-    // previous load: the transactions carry the group (StoreKit 2) without the fetch below.
-    // (Apple-ID-scoped, so an identity change / `reset()` doesn't require clearing it.)
-    activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(from: onDeviceSnapshot, storeProducts: [])
-
     let purchasedProductIds = Set(onDeviceSnapshot.purchases.map { $0.id })
 
     guard let storeProducts = try? await productsManager.products(
@@ -242,10 +237,13 @@ actor ReceiptManager {
       forPaywall: nil,
       placement: nil
     ) else {
+      // Fetch failed: refresh from the snapshot alone so the set still reflects this load.
+      // We assign only *after* the await (here and below), never before, so a re-entrant
+      // `isFreeTrialAvailable` during the suspension can't observe a half-built set.
+      activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(from: onDeviceSnapshot, storeProducts: [])
       return
     }
 
-    // A successful fetch enriches the set with product-derived groups (StoreKit 1's source).
     activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(from: onDeviceSnapshot, storeProducts: storeProducts)
 
     await manager.loadIntroOfferEligibility(forProducts: storeProducts)

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -236,13 +236,38 @@ actor ReceiptManager {
     await manager.loadIntroOfferEligibility(forProducts: storeProducts)
   }
 
-  /// Determines whether a free trial is available based on the product the user is purchasing.
+  /// Determines whether a free trial will actually be granted when the user purchases `storeProduct`.
   ///
-  /// A free trial is available if the user hasn't already purchased within the subscription group of the
-  /// supplied product. If it isn't a subscription-based product or there are other issues retrieving the products,
-  /// the outcome will default to whether or not the user has already purchased that product.
+  /// This is stricter than raw StoreKit intro-offer eligibility. `isEligibleForIntroOffer`
+  /// only reflects whether the customer has ever *consumed* an intro offer in the product's
+  /// subscription group — it returns `true` for someone who has paid for a product in the
+  /// group but never taken a trial. Apple additionally does **not** apply introductory
+  /// offers to upgrades, crossgrades, or downgrades: if the customer already has an active
+  /// subscription in the same subscription group, purchasing a product in that group is a
+  /// product change and no trial is granted, even though `isEligibleForIntroOffer` is `true`.
+  ///
+  /// So we also require that there's no active App Store subscription in the product's group,
+  /// to avoid advertising a free trial that Apple won't honor. (Once the existing subscription
+  /// lapses, a fresh purchase is a new subscription and the trial applies again.)
   func isFreeTrialAvailable(for storeProduct: StoreProduct) async -> Bool {
-    await manager.isEligibleForIntroOffer(storeProduct)
+    let isEligibleForIntroOffer = await manager.isEligibleForIntroOffer(storeProduct)
+    if !isEligibleForIntroOffer {
+      return false
+    }
+
+    // Non-subscription products have no subscription group, so the
+    // upgrade/crossgrade/downgrade rule doesn't apply.
+    guard let subscriptionGroupId = storeProduct.subscriptionGroupIdentifier else {
+      return true
+    }
+
+    let deviceSubscriptions = storage.get(LatestDeviceCustomerInfo.self)?.subscriptions ?? []
+    let hasActiveSubscriptionInGroup = deviceSubscriptions.contains { subscription in
+      subscription.store == .appStore
+        && subscription.isActive
+        && subscription.subscriptionGroupId == subscriptionGroupId
+    }
+    return !hasActiveSubscriptionInGroup
   }
 
   /// Determines whether the user is subscribed to the given product id.

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift
@@ -230,6 +230,11 @@ actor ReceiptManager {
 
     await receiptDelegate?.syncSubscriptionStatus(purchases: onDeviceSnapshot.purchases)
 
+    // Refresh from this load's snapshot first, so the active-group state never describes a
+    // previous load: the transactions carry the group (StoreKit 2) without the fetch below.
+    // (Apple-ID-scoped, so an identity change / `reset()` doesn't require clearing it.)
+    activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(from: onDeviceSnapshot, storeProducts: [])
+
     let purchasedProductIds = Set(onDeviceSnapshot.purchases.map { $0.id })
 
     guard let storeProducts = try? await productsManager.products(
@@ -240,29 +245,18 @@ actor ReceiptManager {
       return
     }
 
-    // Record which subscription groups the user has an *active* subscription in, so
-    // `isFreeTrialAvailable` can suppress trials on upgrades/crossgrades.
-    activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(
-      from: onDeviceSnapshot,
-      storeProducts: storeProducts
-    )
+    // A successful fetch enriches the set with product-derived groups (StoreKit 1's source).
+    activeSubscriptionGroupIds = computeActiveSubscriptionGroupIds(from: onDeviceSnapshot, storeProducts: storeProducts)
 
     await manager.loadIntroOfferEligibility(forProducts: storeProducts)
   }
 
   /// Determines whether a free trial will actually be granted when the user purchases `storeProduct`.
   ///
-  /// This is stricter than raw StoreKit intro-offer eligibility. `isEligibleForIntroOffer`
-  /// only reflects whether the customer has ever *consumed* an intro offer in the product's
-  /// subscription group — it returns `true` for someone who has paid for a product in the
-  /// group but never taken a trial. Apple additionally does **not** apply introductory
-  /// offers to upgrades, crossgrades, or downgrades: if the customer already has an active
-  /// subscription in the same subscription group, purchasing a product in that group is a
-  /// product change and no trial is granted, even though `isEligibleForIntroOffer` is `true`.
-  ///
-  /// So we also require that there's no active subscription in the product's group, to
-  /// avoid advertising a free trial that Apple won't honor. (Once the existing subscription
-  /// lapses, a fresh purchase is a new subscription and the trial applies again.)
+  /// Stricter than raw `isEligibleForIntroOffer` (which only reflects whether the customer ever
+  /// *consumed* an intro in the group): Apple doesn't apply intro offers to upgrades, crossgrades,
+  /// or downgrades, so we also require no active subscription in the product's group. Once the
+  /// existing subscription lapses, a fresh purchase is eligible again.
   func isFreeTrialAvailable(for storeProduct: StoreProduct) async -> Bool {
     let isEligibleForIntroOffer = await manager.isEligibleForIntroOffer(storeProduct)
     if !isEligibleForIntroOffer {

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift
@@ -28,7 +28,9 @@ struct PurchaseSnapshot {
 
 @available(iOS 15.0, *)
 actor SK2ReceiptManager: ReceiptManagerType {
-  private var sk2IntroOfferEligibility: [String: Bool]
+  /// Resolves intro-offer eligibility live from StoreKit. Injectable so tests can
+  /// verify eligibility is re-evaluated on every call rather than cached.
+  private let resolveIntroOfferEligibility: @Sendable (StoreProduct) async -> Bool
   var purchases: Set<Purchase>
   var transactionReceipts: [TransactionReceipt]
   var latestSubscriptionPeriodType: LatestSubscription.PeriodType?
@@ -36,26 +38,29 @@ actor SK2ReceiptManager: ReceiptManagerType {
   var latestSubscriptionState: LatestSubscription.State?
 
   init(
-    sk2IntroOfferEligibility: [String: Bool] = [:],
     purchases: Set<Purchase> = [],
     transactionReceipts: [TransactionReceipt] = [],
     latestSubscriptionPeriodType: LatestSubscription.PeriodType? = nil,
     latestSubscriptionWillAutoRenew: Bool? = nil,
-    latestSubscriptionState: LatestSubscription.State? = nil
+    latestSubscriptionState: LatestSubscription.State? = nil,
+    resolveIntroOfferEligibility: @escaping @Sendable (StoreProduct) async -> Bool
+      = { await SK2ReceiptManager.liveIntroOfferEligibility(for: $0) }
   ) {
-    self.sk2IntroOfferEligibility = sk2IntroOfferEligibility
     self.purchases = purchases
     self.transactionReceipts = transactionReceipts
     self.latestSubscriptionPeriodType = latestSubscriptionPeriodType
     self.latestSubscriptionWillAutoRenew = latestSubscriptionWillAutoRenew
     self.latestSubscriptionState = latestSubscriptionState
+    self.resolveIntroOfferEligibility = resolveIntroOfferEligibility
   }
 
-  func loadIntroOfferEligibility(forProducts storeProducts: Set<StoreProduct>) async {
-    for storeProduct in storeProducts {
-      sk2IntroOfferEligibility[storeProduct.productIdentifier] = await isEligibleForIntroOffer(storeProduct)
-    }
-  }
+  /// No-op for StoreKit 2.
+  ///
+  /// Eligibility is resolved live in `isEligibleForIntroOffer(_:)` on every call
+  /// rather than pre-warmed into a cache. The previous cache froze eligibility for
+  /// the lifetime of the process — it survived `reset()` and user identity switches —
+  /// which could surface a free trial that Apple would not actually grant.
+  func loadIntroOfferEligibility(forProducts _: Set<StoreProduct>) async {}
 
   func loadPurchases(serverEntitlementsByProductId: [String: Set<Entitlement>]) async -> PurchaseSnapshot {
     var purchases: Set<Purchase> = []
@@ -243,12 +248,20 @@ actor SK2ReceiptManager: ReceiptManagerType {
     return latestExpiration
   }
 
+  /// Determines whether `storeProduct` is eligible for an introductory offer.
+  ///
+  /// Always resolved live (never cached): eligibility can change after a purchase
+  /// or a user identity switch via `reset()`, and a stale value would surface a
+  /// free trial that Apple won't grant.
   func isEligibleForIntroOffer(_ storeProduct: StoreProduct) async -> Bool {
+    return await resolveIntroOfferEligibility(storeProduct)
+  }
+
+  /// Live intro-offer eligibility query backed by StoreKit 2. This is the default
+  /// resolver injected into `init`; tests can substitute their own.
+  static func liveIntroOfferEligibility(for storeProduct: StoreProduct) async -> Bool {
     guard let product = storeProduct.product as? SK2StoreProduct else {
       return false
-    }
-    if let eligibility = sk2IntroOfferEligibility[storeProduct.productIdentifier] {
-      return eligibility
     }
     guard product.hasFreeTrial else {
       return false
@@ -258,10 +271,6 @@ actor SK2ReceiptManager: ReceiptManagerType {
       // Technically this is covered in hasFreeTrial, but good for unwrapping subscription
       return false
     }
-    if await renewableSubscription.isEligibleForIntroOffer {
-      // The product is eligible for an introductory offer.
-      return true
-    }
-    return false
+    return await renewableSubscription.isEligibleForIntroOffer
   }
 }

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -153,12 +153,14 @@
 		41EAF9340665BF7459B2C29C /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50458143450675EF205CE2C3 /* CoreDataStack.swift */; };
 		424F0357DA9A8BFBC6621047 /* LogScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCE6A59348C9018F40D7AC5 /* LogScope.swift */; };
 		42B707D898A49DCB2B33837C /* CustomCallbackRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3BC4249A9E9BA8E99EC7C /* CustomCallbackRegistry.swift */; };
+		42FDAFD5AB3EC83713941E32 /* SK2ReceiptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B1E659458AE78C3908562B /* SK2ReceiptManagerTests.swift */; };
 		432FB2AE172725B4ED208416 /* DebugManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383FA48A6E9EF8F30683C9B /* DebugManager.swift */; };
 		43EF1A9F46DECE0EECFD0368 /* HiddenListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B0C261DCC1ED74DD2BF3EA /* HiddenListener.swift */; };
 		44829144E9EFA0CE4A75BBA1 /* ExpressionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A154A9E99D00B9BD8837B798 /* ExpressionLogic.swift */; };
 		44E2AE9B0AED16C48027CD21 /* CustomCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E439B70BB6190AFF6DDB81F2 /* CustomCallback.swift */; };
 		454421E34ED200400A001AE1 /* PaywallManagerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8012E350CCE22B0D892E0F96 /* PaywallManagerLogic.swift */; };
 		480C37A4D7A8AB5EE0760BF1 /* PaywallLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C4D551369C55D8AFB7F96 /* PaywallLogic.swift */; };
+		498C546594CF7A5DA78575AA /* ReceiptManagerTrialEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08CC3D275A02927073952EB /* ReceiptManagerTrialEligibilityTests.swift */; };
 		49A7156A67C8BAB23F97EC39 /* EmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6BF63B250AE0D83DECFCD0 /* EmailTests.swift */; };
 		4A4E5413A8753AFB624D325D /* PermissionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD2580D6C95C96CC3051BCB /* PermissionTypeTests.swift */; };
 		4A4E788046CD308F465B37BF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AD390BC73341A49301B4AA /* ProductsFetcherSK2.swift */; };
@@ -883,6 +885,7 @@
 		8708F74D80CB9A440F34A556 /* FakeContactsAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeContactsAuthorizationStatus.swift; sourceTree = "<group>"; };
 		8719AC2E83128EE469E58C36 /* RedeemRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedeemRequest.swift; sourceTree = "<group>"; };
 		87AD727C5A8639E704F7BE98 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
+		87B1E659458AE78C3908562B /* SK2ReceiptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2ReceiptManagerTests.swift; sourceTree = "<group>"; };
 		884DF3D8A1CA382BFEE9F8F4 /* ArchiveManifestUsage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveManifestUsage.swift; sourceTree = "<group>"; };
 		887834329A06971D86D5282F /* NotificationProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationProtocols.swift; sourceTree = "<group>"; };
 		88EBF6FC3090E004EE1377B4 /* PaywallViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerDelegate.swift; sourceTree = "<group>"; };
@@ -944,6 +947,7 @@
 		9F72210F85864F3000F13646 /* ASN1Coder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Coder.swift; sourceTree = "<group>"; };
 		A00C04BE1449BE21E13B61A0 /* LoggerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerMock.swift; sourceTree = "<group>"; };
 		A07DC8EA2AB02423AEE5DF26 /* EvaluationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationContext.swift; sourceTree = "<group>"; };
+		A08CC3D275A02927073952EB /* ReceiptManagerTrialEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManagerTrialEligibilityTests.swift; sourceTree = "<group>"; };
 		A0B4279B992779CAD5A0694A /* AdServicesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdServicesResponse.swift; sourceTree = "<group>"; };
 		A116633D7246EB7BB7AF7229 /* ExpressionEvaluatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorMock.swift; sourceTree = "<group>"; };
 		A154A9E99D00B9BD8837B798 /* ExpressionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionLogic.swift; sourceTree = "<group>"; };
@@ -1268,6 +1272,8 @@
 				9E3DAD767490972EA30257F9 /* EntitlementProcessorTests.swift */,
 				39B81D88316F06C0C2757F10 /* MockReceiptData.swift */,
 				03471273DF4C875227102BE2 /* ReceiptManagerTests.swift */,
+				A08CC3D275A02927073952EB /* ReceiptManagerTrialEligibilityTests.swift */,
+				87B1E659458AE78C3908562B /* SK2ReceiptManagerTests.swift */,
 			);
 			path = "Receipt Manager";
 			sourceTree = "<group>";
@@ -3304,8 +3310,10 @@
 				847E0BD4BDA515E47608F6A1 /* ProductsFetcherSK2Tests.swift in Sources */,
 				5EF4EE04BAA930A2CC4379A1 /* RawWebMessageHandlerTests.swift in Sources */,
 				3BA17B2DA6B69A7B90D39AF9 /* ReceiptManagerTests.swift in Sources */,
+				498C546594CF7A5DA78575AA /* ReceiptManagerTrialEligibilityTests.swift in Sources */,
 				225D6F5363B1520744EABD86 /* RedeemResponseTests.swift in Sources */,
 				ECA7E9C9898CAB24B56E7054 /* SK2PriceFormatRoundingTests.swift in Sources */,
+				42FDAFD5AB3EC83713941E32 /* SK2ReceiptManagerTests.swift in Sources */,
 				B8483A96A7AE8440AF1E0C3B /* SKProductSubscriptionPeriodMock.swift in Sources */,
 				E1A838C9CE62C9479D0C68F4 /* SWDebugManagerLogicTests.swift in Sources */,
 				C77A626D379969A86B900488 /* SWWebViewLoadingHandlerTests.swift in Sources */,

--- a/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
@@ -132,6 +132,77 @@ struct ReceiptManagerTrialEligibilityTests {
     let product = makeProduct(id: "com.app.lifetime", subscriptionGroup: nil)
     #expect(await manager.isFreeTrialAvailable(for: product) == true)
   }
+
+  // MARK: - Active group computation
+
+  private func subscriptionTransaction(
+    productId: String,
+    group: String?,
+    isActive: Bool
+  ) -> SubscriptionTransaction {
+    return SubscriptionTransaction(
+      transactionId: "txn_\(productId)",
+      productId: productId,
+      purchaseDate: Date(timeIntervalSince1970: 0),
+      willRenew: isActive,
+      isRevoked: false,
+      isInGracePeriod: false,
+      isInBillingRetryPeriod: false,
+      isActive: isActive,
+      expirationDate: nil,
+      subscriptionGroupId: group
+    )
+  }
+
+  @Test("Active group is captured from the transaction even when its product can't be fetched")
+  func activeGroupFromTransactionWhenProductMissing() {
+    // The product (e.g. removed from App Store Connect) isn't in storeProducts, but the
+    // StoreKit 2 transaction still carries the group — so the active group isn't dropped.
+    let snapshot = PurchaseSnapshot(
+      purchases: [Purchase(id: "com.app.silver", isActive: true, purchaseDate: Date(timeIntervalSince1970: 0))],
+      customerInfo: CustomerInfo(
+        subscriptions: [subscriptionTransaction(productId: "com.app.silver", group: "group_A", isActive: true)],
+        nonSubscriptions: [],
+        entitlements: []
+      )
+    )
+    let groups = computeActiveSubscriptionGroupIds(from: snapshot, storeProducts: [])
+    #expect(groups == ["group_A"])
+  }
+
+  @Test("Active group is captured from fetched products (StoreKit 1 path)")
+  func activeGroupFromFetchedProducts() {
+    // StoreKit 1 snapshots have no subscriptions, so the group comes from the fetched product.
+    let snapshot = PurchaseSnapshot(
+      purchases: [Purchase(id: "com.app.silver", isActive: true, purchaseDate: Date(timeIntervalSince1970: 0))],
+      customerInfo: CustomerInfo(subscriptions: [], nonSubscriptions: [], entitlements: [])
+    )
+    let storeProducts: Set<StoreProduct> = [
+      StoreProduct(
+        sk1Product: MockSkProduct(productIdentifier: "com.app.silver", subscriptionGroupIdentifier: "group_A")
+      )
+    ]
+    let groups = computeActiveSubscriptionGroupIds(from: snapshot, storeProducts: storeProducts)
+    #expect(groups == ["group_A"])
+  }
+
+  @Test("Inactive subscriptions don't contribute an active group")
+  func inactiveSubscriptionsExcluded() {
+    let snapshot = PurchaseSnapshot(
+      purchases: [Purchase(id: "com.app.silver", isActive: false, purchaseDate: Date(timeIntervalSince1970: 0))],
+      customerInfo: CustomerInfo(
+        subscriptions: [subscriptionTransaction(productId: "com.app.silver", group: "group_A", isActive: false)],
+        nonSubscriptions: [],
+        entitlements: []
+      )
+    )
+    let storeProducts: Set<StoreProduct> = [
+      StoreProduct(
+        sk1Product: MockSkProduct(productIdentifier: "com.app.silver", subscriptionGroupIdentifier: "group_A")
+      )
+    ]
+    #expect(computeActiveSubscriptionGroupIds(from: snapshot, storeProducts: storeProducts).isEmpty)
+  }
 }
 
 /// Minimal `ReceiptManagerType` whose `isEligibleForIntroOffer` is fully controlled,

--- a/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
@@ -5,17 +5,17 @@
 // Regression tests for a bug where a paywall showed a free trial that Apple never
 // granted. A customer who had paid for a product in a subscription group since 2017
 // (but never taken a trial) is still reported eligible by StoreKit's
-// `isEligibleForIntroOffer`. When they bought a *different* product in that group
-// while their existing subscription was active, Apple treated it as an upgrade and
-// applied no introductory offer — yet the paywall advertised one.
+// `isEligibleForIntroOffer`. When they bought a *different* product in that group while
+// their existing subscription was active, Apple treated it as an upgrade and applied no
+// introductory offer — yet the paywall advertised one.
 //
-// `ReceiptManager.isFreeTrialAvailable` now additionally requires that there's no
-// active App Store subscription in the product's subscription group, since Apple
-// doesn't apply intro offers to upgrades/crossgrades/downgrades.
+// `ReceiptManager.isFreeTrialAvailable` now also requires that there's no active
+// subscription in the product's subscription group. The set of active groups is computed
+// in `loadPurchasedProducts` from the active purchases and their fetched products (so it
+// works for both StoreKit 1 and 2); these tests seed it directly to isolate the gate.
 //
 
 import Foundation
-import StoreKit
 import Testing
 @testable import SuperwallKit
 
@@ -26,18 +26,8 @@ struct ReceiptManagerTrialEligibilityTests {
 
   private func makeReceiptManager(
     isEligibleForIntroOffer: Bool,
-    deviceSubscriptions: [SubscriptionTransaction]
+    activeSubscriptionGroupIds: Set<String>
   ) -> (manager: ReceiptManager, productsManager: ProductsManager) {
-    let storage: Storage = dependencyContainer.storage
-    storage.save(
-      CustomerInfo(
-        subscriptions: deviceSubscriptions,
-        nonSubscriptions: [],
-        entitlements: []
-      ),
-      forType: LatestDeviceCustomerInfo.self
-    )
-
     let productsFetcher = ProductsFetcherSK1Mock(
       productCompletionResult: .success([]),
       entitlementsInfo: dependencyContainer.entitlementsInfo
@@ -55,7 +45,8 @@ struct ReceiptManagerTrialEligibilityTests {
       receiptManager: MockReceiptManagerType(isEligibleForIntroOffer: isEligibleForIntroOffer),
       receiptDelegate: nil,
       factory: dependencyContainer,
-      storage: storage
+      storage: dependencyContainer.storage,
+      activeSubscriptionGroupIds: activeSubscriptionGroupIds
     )
     return (receiptManager, productsManager)
   }
@@ -72,34 +63,12 @@ struct ReceiptManagerTrialEligibilityTests {
     )
   }
 
-  private func activeSubscription(
-    productId: String,
-    group: String?,
-    isActive: Bool = true,
-    store: ProductStore = .appStore
-  ) -> SubscriptionTransaction {
-    return SubscriptionTransaction(
-      transactionId: "txn_\(productId)",
-      productId: productId,
-      purchaseDate: Date(timeIntervalSince1970: 0),
-      willRenew: isActive,
-      isRevoked: false,
-      isInGracePeriod: false,
-      isInBillingRetryPeriod: false,
-      isActive: isActive,
-      expirationDate: nil,
-      offerType: nil,
-      subscriptionGroupId: group,
-      store: store
-    )
-  }
-
   @Test("No trial when an active subscription exists in the same group (upgrade/crossgrade)")
   func noTrialWhenActiveSubscriptionInSameGroup() async {
     // The reported incident: active Silver in group_A, buying Gold in group_A.
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: true,
-      deviceSubscriptions: [activeSubscription(productId: "com.app.silver", group: "group_A")]
+      activeSubscriptionGroupIds: ["group_A"]
     )
     _ = productsManager
     let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
@@ -108,13 +77,11 @@ struct ReceiptManagerTrialEligibilityTests {
 
   @Test("Trial available once the same-group subscription has lapsed")
   func trialWhenSameGroupSubscriptionInactive() async {
-    // After Silver lapsed, a fresh purchase in the group is a new subscription, so
-    // Apple applies the trial again.
+    // After Silver lapsed it's no longer in the active set, so a fresh purchase in the
+    // group is a new subscription and Apple applies the trial again.
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: true,
-      deviceSubscriptions: [
-        activeSubscription(productId: "com.app.silver", group: "group_A", isActive: false)
-      ]
+      activeSubscriptionGroupIds: []
     )
     _ = productsManager
     let silver = makeProduct(id: "com.app.silver", subscriptionGroup: "group_A")
@@ -125,18 +92,18 @@ struct ReceiptManagerTrialEligibilityTests {
   func trialWhenActiveSubscriptionInDifferentGroup() async {
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: true,
-      deviceSubscriptions: [activeSubscription(productId: "com.app.other", group: "group_B")]
+      activeSubscriptionGroupIds: ["group_B"]
     )
     _ = productsManager
     let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
     #expect(await manager.isFreeTrialAvailable(for: gold) == true)
   }
 
-  @Test("Trial available when there are no subscriptions at all")
-  func trialWhenNoSubscriptions() async {
+  @Test("Trial available when there are no active subscriptions")
+  func trialWhenNoActiveSubscriptions() async {
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: true,
-      deviceSubscriptions: []
+      activeSubscriptionGroupIds: []
     )
     _ = productsManager
     let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
@@ -145,29 +112,25 @@ struct ReceiptManagerTrialEligibilityTests {
 
   @Test("No trial when StoreKit reports the customer is intro-ineligible")
   func noTrialWhenIneligible() async {
-    // Even with no blocking subscription, an ineligible customer gets no trial.
+    // Ineligible short-circuits before the active-subscription check.
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: false,
-      deviceSubscriptions: []
+      activeSubscriptionGroupIds: ["group_A"]
     )
     _ = productsManager
     let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
     #expect(await manager.isFreeTrialAvailable(for: gold) == false)
   }
 
-  @Test("A non-App Store subscription in the group does not block the trial")
-  func nonAppStoreSubscriptionDoesNotBlock() async {
-    // The upgrade rule is an App Store concept; a web/Stripe entitlement in the same
-    // group must not suppress an App Store trial.
+  @Test("A product with no subscription group is unaffected by the active-group check")
+  func trialWhenProductHasNoSubscriptionGroup() async {
     let (manager, productsManager) = makeReceiptManager(
       isEligibleForIntroOffer: true,
-      deviceSubscriptions: [
-        activeSubscription(productId: "com.app.silver", group: "group_A", store: .stripe)
-      ]
+      activeSubscriptionGroupIds: ["group_A"]
     )
     _ = productsManager
-    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
-    #expect(await manager.isFreeTrialAvailable(for: gold) == true)
+    let product = makeProduct(id: "com.app.lifetime", subscriptionGroup: nil)
+    #expect(await manager.isFreeTrialAvailable(for: product) == true)
   }
 }
 

--- a/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift
@@ -1,0 +1,200 @@
+//
+//  ReceiptManagerTrialEligibilityTests.swift
+//  SuperwallKitTests
+//
+// Regression tests for a bug where a paywall showed a free trial that Apple never
+// granted. A customer who had paid for a product in a subscription group since 2017
+// (but never taken a trial) is still reported eligible by StoreKit's
+// `isEligibleForIntroOffer`. When they bought a *different* product in that group
+// while their existing subscription was active, Apple treated it as an upgrade and
+// applied no introductory offer — yet the paywall advertised one.
+//
+// `ReceiptManager.isFreeTrialAvailable` now additionally requires that there's no
+// active App Store subscription in the product's subscription group, since Apple
+// doesn't apply intro offers to upgrades/crossgrades/downgrades.
+//
+
+import Foundation
+import StoreKit
+import Testing
+@testable import SuperwallKit
+
+struct ReceiptManagerTrialEligibilityTests {
+  // Held for the lifetime of each test: `ReceiptManager` keeps an `unowned` reference
+  // to its factory, so the container must outlive the manager.
+  let dependencyContainer = DependencyContainer()
+
+  private func makeReceiptManager(
+    isEligibleForIntroOffer: Bool,
+    deviceSubscriptions: [SubscriptionTransaction]
+  ) -> (manager: ReceiptManager, productsManager: ProductsManager) {
+    let storage: Storage = dependencyContainer.storage
+    storage.save(
+      CustomerInfo(
+        subscriptions: deviceSubscriptions,
+        nonSubscriptions: [],
+        entitlements: []
+      ),
+      forType: LatestDeviceCustomerInfo.self
+    )
+
+    let productsFetcher = ProductsFetcherSK1Mock(
+      productCompletionResult: .success([]),
+      entitlementsInfo: dependencyContainer.entitlementsInfo
+    )
+    let productsManager = ProductsManager(
+      entitlementsInfo: dependencyContainer.entitlementsInfo,
+      storeKitVersion: .storeKit1,
+      productsFetcher: productsFetcher
+    )
+
+    let receiptManager = ReceiptManager(
+      storeKitVersion: .storeKit2,
+      shouldBypassAppTransactionCheck: true,
+      productsManager: productsManager,
+      receiptManager: MockReceiptManagerType(isEligibleForIntroOffer: isEligibleForIntroOffer),
+      receiptDelegate: nil,
+      factory: dependencyContainer,
+      storage: storage
+    )
+    return (receiptManager, productsManager)
+  }
+
+  private func makeProduct(
+    id: String = "com.app.gold",
+    subscriptionGroup: String? = "group_A"
+  ) -> StoreProduct {
+    return StoreProduct(
+      sk1Product: MockSkProduct(
+        productIdentifier: id,
+        subscriptionGroupIdentifier: subscriptionGroup
+      )
+    )
+  }
+
+  private func activeSubscription(
+    productId: String,
+    group: String?,
+    isActive: Bool = true,
+    store: ProductStore = .appStore
+  ) -> SubscriptionTransaction {
+    return SubscriptionTransaction(
+      transactionId: "txn_\(productId)",
+      productId: productId,
+      purchaseDate: Date(timeIntervalSince1970: 0),
+      willRenew: isActive,
+      isRevoked: false,
+      isInGracePeriod: false,
+      isInBillingRetryPeriod: false,
+      isActive: isActive,
+      expirationDate: nil,
+      offerType: nil,
+      subscriptionGroupId: group,
+      store: store
+    )
+  }
+
+  @Test("No trial when an active subscription exists in the same group (upgrade/crossgrade)")
+  func noTrialWhenActiveSubscriptionInSameGroup() async {
+    // The reported incident: active Silver in group_A, buying Gold in group_A.
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: true,
+      deviceSubscriptions: [activeSubscription(productId: "com.app.silver", group: "group_A")]
+    )
+    _ = productsManager
+    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: gold) == false)
+  }
+
+  @Test("Trial available once the same-group subscription has lapsed")
+  func trialWhenSameGroupSubscriptionInactive() async {
+    // After Silver lapsed, a fresh purchase in the group is a new subscription, so
+    // Apple applies the trial again.
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: true,
+      deviceSubscriptions: [
+        activeSubscription(productId: "com.app.silver", group: "group_A", isActive: false)
+      ]
+    )
+    _ = productsManager
+    let silver = makeProduct(id: "com.app.silver", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: silver) == true)
+  }
+
+  @Test("Trial available when the active subscription is in a different group")
+  func trialWhenActiveSubscriptionInDifferentGroup() async {
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: true,
+      deviceSubscriptions: [activeSubscription(productId: "com.app.other", group: "group_B")]
+    )
+    _ = productsManager
+    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: gold) == true)
+  }
+
+  @Test("Trial available when there are no subscriptions at all")
+  func trialWhenNoSubscriptions() async {
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: true,
+      deviceSubscriptions: []
+    )
+    _ = productsManager
+    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: gold) == true)
+  }
+
+  @Test("No trial when StoreKit reports the customer is intro-ineligible")
+  func noTrialWhenIneligible() async {
+    // Even with no blocking subscription, an ineligible customer gets no trial.
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: false,
+      deviceSubscriptions: []
+    )
+    _ = productsManager
+    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: gold) == false)
+  }
+
+  @Test("A non-App Store subscription in the group does not block the trial")
+  func nonAppStoreSubscriptionDoesNotBlock() async {
+    // The upgrade rule is an App Store concept; a web/Stripe entitlement in the same
+    // group must not suppress an App Store trial.
+    let (manager, productsManager) = makeReceiptManager(
+      isEligibleForIntroOffer: true,
+      deviceSubscriptions: [
+        activeSubscription(productId: "com.app.silver", group: "group_A", store: .stripe)
+      ]
+    )
+    _ = productsManager
+    let gold = makeProduct(id: "com.app.gold", subscriptionGroup: "group_A")
+    #expect(await manager.isFreeTrialAvailable(for: gold) == true)
+  }
+}
+
+/// Minimal `ReceiptManagerType` whose `isEligibleForIntroOffer` is fully controlled,
+/// so tests can isolate `ReceiptManager`'s upgrade/crossgrade gating logic.
+private final class MockReceiptManagerType: ReceiptManagerType {
+  let isEligibleForIntroOfferResult: Bool
+  var purchases: Set<Purchase> = []
+  var transactionReceipts: [TransactionReceipt] = []
+  var latestSubscriptionPeriodType: LatestSubscription.PeriodType?
+  var latestSubscriptionWillAutoRenew: Bool?
+  var latestSubscriptionState: LatestSubscription.State?
+
+  init(isEligibleForIntroOffer: Bool) {
+    self.isEligibleForIntroOfferResult = isEligibleForIntroOffer
+  }
+
+  func loadIntroOfferEligibility(forProducts _: Set<StoreProduct>) async {}
+
+  func loadPurchases(serverEntitlementsByProductId _: [String: Set<Entitlement>]) async -> PurchaseSnapshot {
+    return PurchaseSnapshot(
+      purchases: [],
+      customerInfo: CustomerInfo(subscriptions: [], nonSubscriptions: [], entitlements: [])
+    )
+  }
+
+  func isEligibleForIntroOffer(_ storeProduct: StoreProduct) async -> Bool {
+    return isEligibleForIntroOfferResult
+  }
+}

--- a/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/SK2ReceiptManagerTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/SK2ReceiptManagerTests.swift
@@ -1,0 +1,125 @@
+//
+//  SK2ReceiptManagerTests.swift
+//  SuperwallKitTests
+//
+// Regression tests for a bug where SK2 introductory-offer eligibility was cached
+// in `SK2ReceiptManager` for the lifetime of the app process. The cache was never
+// invalidated — it survived `reset()`, user identity switches, and purchases — so a
+// paywall could show a free trial that Apple would not actually grant. The fix
+// removes the cache and resolves eligibility live from StoreKit on every call.
+//
+
+import Foundation
+import Testing
+@testable import SuperwallKit
+
+struct SK2ReceiptManagerTests {
+  /// A lightweight StoreProduct to feed the manager. The injected resolvers in
+  /// these tests ignore the product, so an SK1-backed mock product is sufficient.
+  private func makeStoreProduct() -> StoreProduct {
+    return StoreProduct(
+      sk1Product: MockSkProduct(
+        productIdentifier: "com.superwall.product",
+        subscriptionGroupIdentifier: "group"
+      ),
+      entitlements: []
+    )
+  }
+
+  @Test("isEligibleForIntroOffer re-queries StoreKit on every call and is never cached")
+  func eligibilityIsNotCached() async {
+    guard #available(iOS 15.0, *) else {
+      return
+    }
+    // Returns `true` on the first call and `false` afterwards, simulating Apple's
+    // eligibility flipping once the user has consumed their intro offer. A cache
+    // would freeze the first `true` and return it forever.
+    let calls = CallCounter()
+    let manager = SK2ReceiptManager(
+      resolveIntroOfferEligibility: { _ in
+        await calls.increment() == 1
+      }
+    )
+    let product = makeStoreProduct()
+
+    let first = await manager.isEligibleForIntroOffer(product)
+    let second = await manager.isEligibleForIntroOffer(product)
+
+    #expect(first == true)
+    #expect(second == false)
+    // StoreKit must be consulted on each call rather than served from a cache.
+    #expect(await calls.count == 2)
+  }
+
+  @Test("loadIntroOfferEligibility is a no-op and does not freeze a value for later reads")
+  func loadDoesNotFreezeEligibility() async {
+    guard #available(iOS 15.0, *) else {
+      return
+    }
+    // Eligibility starts `true`, then becomes `false` (e.g. after the user starts a
+    // trial). The old implementation called `isEligibleForIntroOffer` inside
+    // `loadIntroOfferEligibility` and cached the result, so the later read returned a
+    // stale `true`. The fixed implementation must reflect the current value.
+    let eligibility = MutableFlag(value: true)
+    let manager = SK2ReceiptManager(
+      resolveIntroOfferEligibility: { _ in
+        await eligibility.read()
+      }
+    )
+    let product = makeStoreProduct()
+
+    // `loadIntroOfferEligibility` is now a no-op — it must not consult the resolver
+    // (the old code queried eligibility here and cached the result).
+    await manager.loadIntroOfferEligibility(forProducts: [product])
+    #expect(await eligibility.reads == 0)
+
+    #expect(await manager.isEligibleForIntroOffer(product) == true)
+
+    await eligibility.set(false)
+    #expect(await manager.isEligibleForIntroOffer(product) == false)
+
+    // One read per `isEligibleForIntroOffer` call — never served from a frozen value.
+    #expect(await eligibility.reads == 2)
+  }
+
+  @Test("the default resolver runs the live StoreKit path end-to-end")
+  func defaultResolverIsWired() async {
+    guard #available(iOS 15.0, *) else {
+      return
+    }
+    // No custom resolver, so the production default `liveIntroOfferEligibility(for:)`
+    // runs. A StoreKit 1-backed product isn't an `SK2StoreProduct`, so the live path
+    // short-circuits to `false` without touching StoreKit. This proves the default
+    // resolver is wired through `init` and the no-cache path runs end-to-end.
+    let manager = SK2ReceiptManager()
+    let sk1BackedProduct = makeStoreProduct()
+    #expect(await manager.isEligibleForIntroOffer(sk1BackedProduct) == false)
+  }
+}
+
+private actor CallCounter {
+  private(set) var count = 0
+
+  func increment() -> Int {
+    count += 1
+    return count
+  }
+}
+
+private actor MutableFlag {
+  private(set) var value: Bool
+  private(set) var reads = 0
+
+  init(value: Bool) {
+    self.value = value
+  }
+
+  func read() -> Bool {
+    reads += 1
+    return value
+  }
+
+  func set(_ newValue: Bool) {
+    value = newValue
+  }
+}


### PR DESCRIPTION
## Summary

A paywall could advertise a **free trial that Apple never granted**, then charge the user immediately on purchase.

**Root cause:** StoreKit's `Product.SubscriptionInfo.isEligibleForIntroOffer` only reflects whether the customer has ever *consumed* an intro offer in the subscription group — it returns `true` for someone who paid for a product in the group but never took a trial. Apple separately **does not apply introductory offers to upgrades, crossgrades, or downgrades**: when a customer with an active subscription in a group buys a different product in that same group, it's a product change and no trial is applied — regardless of the eligibility flag.

Real-world case: a user subscribed to a lower tier since 2017 (never trialed) bought a higher tier while the lower tier was still active. `isEligibleForIntroOffer` was `true`, the paywall showed a trial, but Apple returned `PURCHASED` with no trial and charged them. A week later, after the original subscription lapsed, they bought fresh and Apple *did* grant the 30-day trial — confirming the difference is "new subscription vs. product change," not eligibility.

## Changes

**1. Gate trial availability on active subscription state (the fix)**
`ReceiptManager.isFreeTrialAvailable` now also requires that there is **no active subscription in the product's subscription group**. The set of active subscription groups is computed in `loadPurchasedProducts` from the active purchases and their fetched products — those carry the group ID for **both** StoreKit 1 and StoreKit 2. `loadPurchasedProducts` always completes before a paywall opens (config is only marked `retrieved` after it runs, and presentation blocks on config), so the gate reflects current subscription state regardless of StoreKit version. Once the existing subscription lapses, a fresh purchase is eligible for the trial again.

**2. Remove the never-invalidated SK2 eligibility cache**
`SK2ReceiptManager` cached intro-offer eligibility in a dict that was never invalidated — it survived `reset()`, identity switches, and purchases for the whole app-process lifetime. Eligibility is now queried live from StoreKit on each check (a local on-device read, not a network call). Low-severity latent fix; the gate above covers the common scenario. *Easy to split out if you'd prefer to land it separately.*

## Test plan
- `ReceiptManagerTrialEligibilityTests` (6 tests): active sub in same group → no trial; lapsed sub → trial returns; different group / no active subs → unaffected; ineligible → no trial; product with no subscription group → unaffected.
- `SK2ReceiptManagerTests` (3 tests): eligibility re-queried each call (not cached); `loadIntroOfferEligibility` is a no-op; default live resolver is wired.
- **Full suite: 833 tests pass** (run with parallelism disabled). `swiftlint` clean on all changed files.

> [!NOTE]
> One pre-existing test, `CustomProductTests.prepareToPurchase_customProduct_marksFreeTrialAvailableWhenUserHasNoPriorEntitlement`, fails **only under parallel execution** — it mutates the global `Superwall.shared.customerInfo`, which a sibling test races. It passes in isolation and with parallelism disabled, and is not on this PR's code path. Happy to make it order-independent in a follow-up if you'd like CI green under parallelism.

## Checklist
- [x] All unit tests pass. *(833 pass serially; see note re: the pre-existing parallel-only flake)*
- [ ] All UI tests pass. *(not run)*
- [ ] Demo project builds and runs on iOS. *(not run)*
- [ ] Demo project builds and runs on Mac Catalyst. *(not run)*
- [ ] Demo project builds and runs on visionOS. *(not run)*
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs. *(no public API change)*
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes trial messaging for subscription product changes. The main changes are:

- Track active subscription groups during receipt loading.
- Suppress free-trial display for upgrades, crossgrades, and downgrades in the same group.
- Resolve StoreKit 2 intro-offer eligibility live instead of using a process-lifetime cache.
- Add tests for active-group gating and live SK2 eligibility reads.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/ReceiptManager.swift | Adds active subscription-group tracking and uses it to gate free-trial availability for same-group product changes. |
| Sources/SuperwallKit/StoreKit/Products/Receipt Manager/Receipt Manager/SK2ReceiptManager.swift | Removes cached SK2 intro-offer eligibility and routes each check through a live resolver. |
| Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/ReceiptManagerTrialEligibilityTests.swift | Adds tests for trial gating with active, inactive, same-group, and different-group subscription states. |
| Tests/SuperwallKitTests/StoreKit/Products/Receipt Manager/SK2ReceiptManagerTests.swift | Adds tests that SK2 eligibility is re-read on each call and that preload no longer freezes a value. |
| SuperwallKit.xcodeproj/project.pbxproj | Adds the new receipt-manager test files to the Xcode test target. |

<sub>Reviews (4): Last reviewed commit: ["Address review: don&#39;t publish a half-bui..."](https://github.com/superwall/superwall-ios/commit/495161c82502f20d21ab044c50dc381f80705938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39823326)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/superwall/github/superwall/superwall-ios/-/custom-context?memory=ae0afcf7-0b55-482b-9764-29f361e46714))

<!-- /greptile_comment -->