### PR TITLE
Release 4.15.4 with Singular integration attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.15.4
+
+### Enhancements
+
+- Adds `singularDeviceId` as an `IntegrationAttribute`.
+
 ## 4.15.3
 
 ### Fixes

--- a/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
@@ -73,6 +73,9 @@ public enum IntegrationAttribute: Int {
 
   /// The Appstack identifier.
   case appstackId
+
+  /// The Singular device identifier (SDID).
+  case singularDeviceId
 }
 
 // MARK: - CustomStringConvertible
@@ -123,6 +126,8 @@ extension IntegrationAttribute: CustomStringConvertible {
       return "customerioId"
     case .appstackId:
       return "appstackId"
+    case .singularDeviceId:
+      return "singularDeviceId"
     }
   }
 }

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.15.3
+4.15.4
 """

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.15.3"
+  s.version      = "4.15.4"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Analytics/Attribution/AttributionTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Attribution/AttributionTests.swift
@@ -348,7 +348,8 @@ struct AttributionTests {
         .tenjinId: "tenjin-id",
         .posthogUserId: "posthog-user-id",
         .customerioId: "customerio-id",
-        .appstackId: "appstack-id"
+        .appstackId: "appstack-id",
+        .singularDeviceId: "singular-device-id"
       ]
       
       // When
@@ -378,6 +379,7 @@ struct AttributionTests {
       #expect(storedProps["posthogUserId"] as? String == "posthog-user-id")
       #expect(storedProps["customerioId"] as? String == "customerio-id")
       #expect(storedProps["appstackId"] as? String == "appstack-id")
+      #expect(storedProps["singularDeviceId"] as? String == "singular-device-id")
     }
   }
 


### PR DESCRIPTION
## Summary
- Bumps SuperwallKit to `4.15.4` from the current `master` release base
- Adds `singularDeviceId` to `IntegrationAttribute`
- Covers serialization in attribution tests
- Adds the `4.15.4` changelog entry

## Release behavior
Merging this into `master` should trigger `.github/workflows/tag-version.yml`, which tags `4.15.4`, creates `release/4.15.4`, and publishes CocoaPods.

## Verification
- `git diff --check`

Local builds/tests not run; branch push will run the repo GitHub Actions.