### PR TITLE
Skip MMP install match when event tracking is opted out

### DIFF
--- a/Sources/SuperwallKit/Config/Options/EventTrackingBehavior.swift
+++ b/Sources/SuperwallKit/Config/Options/EventTrackingBehavior.swift
@@ -16,7 +16,10 @@ import Foundation
 /// - `.superwallOnly`: Only internal Superwall events are tracked. User-initiated
 ///   ``Superwall/track(event:params:)`` calls, trigger fires, and user-attribute updates
 ///   are suppressed. Equivalent to the deprecated `isExternalDataCollectionEnabled = false`.
-/// - `.none`: No events are sent to the Superwall servers.
+/// - `.none`: No events are sent to the Superwall servers. Install-attribution
+///   matching is also skipped, so `acquisition_*` user attributes won't populate
+///   and audience rules that rely on them won't match. Use `.superwallOnly` if
+///   you need attribution-based targeting with minimal tracking.
 @objc(SWKEventTrackingBehavior)
 public enum EventTrackingBehavior: Int, CustomStringConvertible, Encodable, Sendable {
   /// All events are tracked. This is the default.
@@ -29,6 +32,12 @@ public enum EventTrackingBehavior: Int, CustomStringConvertible, Encodable, Send
   case superwallOnly = 1
 
   /// No events are sent to the Superwall servers.
+  ///
+  /// Install-attribution matching is also skipped — it would otherwise post
+  /// device metadata to the backend, bypassing the opt-out. Because the match
+  /// never runs, `acquisition_*` user attributes aren't populated, so audience
+  /// rules that depend on them won't match. Use ``superwallOnly`` instead if you
+  /// need attribution-based targeting with minimal tracking.
   case none = 2
 
   public var description: String {

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -489,10 +489,15 @@ public final class Superwall: NSObject, ObservableObject {
 
       _ = await configureIdentity
 
-      if dependencyContainer.storage.shouldAttemptInitialMMPInstallAttributionMatch(
-        hadTrackedAppInstallBeforeConfigure: hadTrackedAppInstallBeforeConfigure,
-        appInstalledAtString: dependencyContainer.deviceHelper.appInstalledAtString
-      ) {
+      // Skip install-attribution matching entirely when the developer has
+      // opted out of all event collection. The `/api/match` call and the
+      // `acquisition_*` attribute writes happen outside the event queue, so
+      // queue-level suppression wouldn't catch them.
+      if dependencyContainer.configManager.options.eventTrackingBehavior != .none,
+        dependencyContainer.storage.shouldAttemptInitialMMPInstallAttributionMatch(
+          hadTrackedAppInstallBeforeConfigure: hadTrackedAppInstallBeforeConfigure,
+          appInstalledAtString: dependencyContainer.deviceHelper.appInstalledAtString
+        ) {
         let advertiserTrackingEnabled =
           dependencyContainer.permissionHandler.checkTrackingPermission() == .granted
 


### PR DESCRIPTION
## Changes in this pull request

Addresses a code-review finding on the install-attribution flow: when a developer sets `eventTrackingBehavior` to `.none` before `configure()`, the MMP install match still ran — reading the IDFA state, posting device metadata to `/api/match`, and potentially writing `acquisition_*` user attributes. Those actions happen **outside** the event queue, so queue-level suppression never caught them, letting attribution bypass the full opt-out.

- Gate the initial install-match block on `eventTrackingBehavior != .none`. Under `.none` the `if` is skipped entirely — no IDFA read, no `/api/match` call, no attribute write.

Note on testing: this is a one-line inline guard in `configure()`'s setup task; the matching internals it gates are already covered by `MMPInstallAttributionTests` at the `Storage` layer, and there's no clean unit-test seam for the configure-time gate itself. Verified via SwiftLint (0 violations) and a successful build.

### Checklist

- [ ] All unit tests pass.
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [ ] I added/updated tests or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates initial install attribution on event tracking settings. The main changes are:

- Skips the initial MMP install match when event tracking is `.none`.
- Avoids the direct `/api/match` call for pre-configure opt-out.
- Avoids attribution attribute writes for that pre-configure opt-out path.

<h3>Confidence Score: 4/5</h3>

The configure-time attribution gate needs a synchronization fix before merging.

- Pre-configure `.none` appears to skip the new attribution path as intended.
- Immediate post-configure opt-out can race with the async setup task.
- Once the match starts, the direct request and attribution writes are outside the event queue.

Sources/SuperwallKit/Superwall.swift

<details open><summary><h3>Security Review</h3></summary>

An immediate post-configure tracking opt-out can still race with the async install-attribution task, allowing attribution metadata to be sent before `.none` is observed.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Superwall.swift | Adds an event-tracking guard around the initial MMP install-attribution match, but the guard is read from an async setup task. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Sources/SuperwallKit/Superwall.swift:496
**Opt-Out Guard Races Configure**

When an app disables tracking with `Superwall.shared.eventTrackingBehavior = .none` immediately after `configure()` returns, this background setup task can read the default `.all` first and start the install match anyway. That sends the direct `/api/match` request and can persist `acquisition_*` attributes before the opt-out state is observed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Skip MMP install match when event tracki..."](https://github.com/superwall/superwall-ios/commit/36fa3b6d932624e028367a9cdece80ba90579df8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40563741)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/superwall/github/superwall/superwall-ios/-/custom-context?memory=ae0afcf7-0b55-482b-9764-29f361e46714))

<!-- /greptile_comment -->