### PR TITLE
[codex] Clarify OneSignal user ID attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 4.16.1
 
+### Enhancements
+
+- Clarifies that `IntegrationAttribute.onesignalId` should be set to the OneSignal User ID used by the OneSignal integration.
+
 ### Fixes
 
 - Makes sure that the compiler directive is correct for billing plan types so that the SDK builds in Xcode version 26.4.
@@ -16,7 +20,6 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Adds support for annual subscriptions that are billed monthly.
 - Added `EventTrackingBehavior` enum and `SuperwallOptions.eventTrackingBehavior` property for GDPR-compliant event collection control. Use `.all` (default) to track everything, `.superwallOnly` to suppress user-initiated tracking, trigger fires, and user-attribute updates while keeping internal SDK events, or `.none` to stop all event collection entirely. The behavior can also be changed at runtime via `Superwall.shared.eventTrackingBehavior`.
 - Deprecated `SuperwallOptions.isExternalDataCollectionEnabled`. Setting it to `false` now maps to `.superwallOnly`; setting it back to `true` maps to `.all`.
-- Clarifies that `IntegrationAttribute.onesignalId` should be set to the OneSignal User ID used by the OneSignal integration.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Adds support for annual subscriptions that are billed monthly.
 - Added `EventTrackingBehavior` enum and `SuperwallOptions.eventTrackingBehavior` property for GDPR-compliant event collection control. Use `.all` (default) to track everything, `.superwallOnly` to suppress user-initiated tracking, trigger fires, and user-attribute updates while keeping internal SDK events, or `.none` to stop all event collection entirely. The behavior can also be changed at runtime via `Superwall.shared.eventTrackingBehavior`.
 - Deprecated `SuperwallOptions.isExternalDataCollectionEnabled`. Setting it to `false` now maps to `.superwallOnly`; setting it back to `true` maps to `.all`.
+- Clarifies that `IntegrationAttribute.onesignalId` should be set to the OneSignal User ID used by the OneSignal integration.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
+++ b/Sources/SuperwallKit/Analytics/Attribution/IntegrationAttribute.swift
@@ -26,7 +26,7 @@ public enum IntegrationAttribute: Int {
   /// The Braze `alias_label` in User Alias Object.
   case brazeAliasLabel
 
-  /// The OneSignal Player identifier for the user.
+  /// The OneSignal User ID (`onesignal_id`) for the user.
   case onesignalId
 
   /// The Facebook Anonymous identifier for the user.


### PR DESCRIPTION
## Summary
- Clarify that `IntegrationAttribute.onesignalId` should contain the OneSignal User ID.
- Add the changelog note for the SDK documentation clarification.

## Validation
- Ran staged whitespace checks with `git diff --cached --check`.
- Not run: builds, tests, or lint per repo preference.