### PR TITLE
feat: resolve preview paywall by id instead of fetching all paywalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## Unreleased
+
+### Fixes
+
+- Fixes the debugger paywall preview so its resolve request authenticates with the debugger's signed preview token instead of the app's public API key.
+
 ## 4.16.2
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Fixes network requests that can never succeed, such as those with an invalid API key, taking up to a minute to fail instead of failing straight away. Timeouts and server errors still retry as before.
 - Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
 - Fixes issue where the paywall debugger wouldn't work for accounts with many paywalls.
-- Fixes a Main Thread Checker warning caused by reading the device's text size and appearance off the main thread.
 
 ## 4.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
-## Unreleased
-
-### Fixes
-
-- Fixes the debugger paywall preview so its resolve request authenticates with the debugger's signed preview token instead of the app's public API key.
-
 ## 4.16.2
 
 ### Enhancements
@@ -19,6 +13,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Fixes network requests that can never succeed, such as those with an invalid API key, taking up to a minute to fail instead of failing straight away. Timeouts and server errors still retry as before.
 - Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
+- Fixes issue where the paywall debugger wouldn't work for accounts with many paywalls.
+- Fixes a Main Thread Checker warning caused by reading the device's text size and appearance off the main thread.
 
 ## 4.16.1
 

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -216,6 +216,24 @@ public final class SuperwallOptions: NSObject, Encodable {
       }
     }
 
+    /// Host for the Superwall V2 API (the `apps/api` Cloudflare Worker), whose
+    /// routes live under a `/v2/` path.
+    ///
+    /// This is a DIFFERENT host from ``baseHost`` (the legacy v1 API on
+    /// `api.superwall.me`): the V2 API is served from the `superwall.com`
+    /// domain — `api.superwall.com` in production and `api.superwall.dev` in the
+    /// developer/staging environment.
+    var apiV2Host: String {
+      switch self {
+      case .developer:
+        return "api.superwall.dev"
+      case .local:
+        return "localhost:3001"
+      default:
+        return "api.superwall.com"
+      }
+    }
+
     /// The base URL for the Superwall dashboard.
     var dashboardBaseUrl: String {
       switch self {

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -118,6 +118,9 @@ final class DebugViewController: UIViewController {
   var paywallDatabaseId: String?
 	var paywallIdentifier: String?
   var paywall: Paywall?
+  /// Backed the "Your Paywalls" picker. Retained (always empty) now that the
+  /// preview flow resolves a single paywall by id instead of fetching all of
+  /// them; see `pressedPreview`.
   var paywalls: [Paywall] = []
   var previewViewContent: UIView?
   private var cancellable: AnyCancellable?
@@ -204,22 +207,7 @@ final class DebugViewController: UIViewController {
   func loadPreview() async {
     activityIndicator.startAnimating()
     previewViewContent?.removeFromSuperview()
-
-    if paywalls.isEmpty {
-      do {
-        paywalls = try await network.getPaywalls()
-        await finishLoadingPreview()
-      } catch {
-        Logger.debug(
-          logLevel: .error,
-          scope: .debugViewController,
-          message: "Failed to Fetch Paywalls",
-          error: error
-        )
-      }
-    } else {
-      await finishLoadingPreview()
-    }
+    await finishLoadingPreview()
   }
 
 	func finishLoadingPreview() async {
@@ -228,8 +216,22 @@ final class DebugViewController: UIViewController {
 		if let paywallIdentifier = paywallIdentifier {
 			paywallId = paywallIdentifier
 		} else if let paywallDatabaseId = paywallDatabaseId {
-			paywallId = paywalls.first { $0.databaseId == paywallDatabaseId }?.identifier
-			paywallIdentifier = paywallId
+      // Resolve the numeric database id from the deep link to the paywall's
+      // identifier (slug) with a single lookup, rather than fetching every
+      // paywall for the app and filtering in memory.
+      do {
+        let resolution = try await network.resolvePaywallIdentifier(forDatabaseId: paywallDatabaseId)
+        paywallId = resolution.identifier
+        paywallIdentifier = resolution.identifier
+      } catch {
+        Logger.debug(
+          logLevel: .error,
+          scope: .debugViewController,
+          message: "Failed to Resolve Paywall",
+          error: error
+        )
+        return
+      }
     } else {
       return
     }
@@ -312,6 +314,11 @@ final class DebugViewController: UIViewController {
 
   @objc func pressedPreview() {
     guard let id = paywallDatabaseId else { return }
+
+    // The "Your Paywalls" picker listed every paywall from the (now removed)
+    // fetch-all. Preview opens one specific paywall by id, so there is no list
+    // to choose from; bail out rather than present an empty sheet.
+    guard !paywalls.isEmpty else { return }
 
     let options: [AlertOption] = paywalls.map { paywall in
       var name = paywall.name

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -75,7 +75,7 @@ final class DebugViewController: UIViewController {
     return button
   }()
 
-  lazy var previewPickerButton: SWBounceButton = {
+  lazy var previewNameButton: SWBounceButton = {
     let button = SWBounceButton()
     button.setTitle("", for: .normal)
     button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
@@ -86,14 +86,11 @@ final class DebugViewController: UIViewController {
     button.setTitleColor(primaryColor, for: .normal)
     button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
     button.translatesAutoresizingMaskIntoConstraints = false
-    button.imageView?.tintColor = primaryColor
     button.layer.cornerRadius = 10
-
-    let image = UIImage(named: "SuperwallKit_down_arrow", in: Bundle.module, compatibleWith: nil)!
-    button.semanticContentAttribute = .forceRightToLeft
-    button.setImage(image, for: .normal)
-    button.imageView?.tintColor = primaryColor
-    button.addTarget(self, action: #selector(pressedPreview), for: .primaryActionTriggered)
+    // Display-only chip showing the previewed paywall's name. The multi-paywall
+    // picker (a dropdown opened from this chip) was removed when the preview
+    // flow stopped fetching all paywalls, so it no longer responds to taps.
+    button.isUserInteractionEnabled = false
     return button
   }()
 
@@ -111,17 +108,12 @@ final class DebugViewController: UIViewController {
     let button = SWBounceButton()
     button.shouldAnimateLightly = true
     button.translatesAutoresizingMaskIntoConstraints = false
-    button.addTarget(self, action: #selector(pressedPreview), for: .primaryActionTriggered)
     return button
   }()
 
   var paywallDatabaseId: String?
 	var paywallIdentifier: String?
   var paywall: Paywall?
-  /// Backed the "Your Paywalls" picker. Retained (always empty) now that the
-  /// preview flow resolves a single paywall by id instead of fetching all of
-  /// them; see `pressedPreview`.
-  var paywalls: [Paywall] = []
   var previewViewContent: UIView?
   private var cancellable: AnyCancellable?
   private var initialLocaleIdentifier: String?
@@ -168,7 +160,7 @@ final class DebugViewController: UIViewController {
     view.addSubview(consoleButton)
     view.addSubview(exitButton)
     view.addSubview(bottomButton)
-    previewContainerView.addSubview(previewPickerButton)
+    previewContainerView.addSubview(previewNameButton)
     view.backgroundColor = lightBackgroundColor
 
     previewContainerView.clipsToBounds = false
@@ -198,9 +190,9 @@ final class DebugViewController: UIViewController {
       bottomButton.widthAnchor.constraint(equalTo: view.layoutMarginsGuide.widthAnchor, constant: -40),
       bottomButton.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor, constant: -10),
 
-      previewPickerButton.centerXAnchor.constraint(equalTo: previewContainerView.centerXAnchor, constant: 0),
-      previewPickerButton.heightAnchor.constraint(equalToConstant: 26),
-      previewPickerButton.centerYAnchor.constraint(equalTo: previewContainerView.bottomAnchor)
+      previewNameButton.centerXAnchor.constraint(equalTo: previewContainerView.centerXAnchor, constant: 0),
+      previewNameButton.heightAnchor.constraint(equalToConstant: 26),
+      previewNameButton.centerYAnchor.constraint(equalTo: previewContainerView.bottomAnchor)
     ])
   }
 
@@ -250,7 +242,7 @@ final class DebugViewController: UIViewController {
       paywall.productVariables = productVariables
 
       self.paywall = paywall
-      self.previewPickerButton.setTitle("\(paywall.name)", for: .normal)
+      self.previewNameButton.setTitle("\(paywall.name)", for: .normal)
       self.activityIndicator.stopAnimating()
       self.addPaywallPreview()
     } catch {
@@ -310,41 +302,6 @@ final class DebugViewController: UIViewController {
     ) {
       child.view.alpha = 1.0
     }
-  }
-
-  @objc func pressedPreview() {
-    guard let id = paywallDatabaseId else { return }
-
-    // The "Your Paywalls" picker listed every paywall from the (now removed)
-    // fetch-all. Preview opens one specific paywall by id, so there is no list
-    // to choose from; bail out rather than present an empty sheet.
-    guard !paywalls.isEmpty else { return }
-
-    let options: [AlertOption] = paywalls.map { paywall in
-      var name = paywall.name
-
-      if id == paywall.databaseId {
-        name = "\(name) ✓"
-      }
-
-      let alert = AlertOption(
-        title: name,
-        action: { [weak self] in
-          self?.paywallDatabaseId = paywall.databaseId
-          self?.paywallIdentifier = paywall.identifier
-          Task { await self?.loadPreview() }
-        },
-        style: .default
-      )
-      return alert
-    }
-
-    presentAlert(
-      title: nil,
-      message: "Your Paywalls",
-      options: options,
-      on: previewPickerButton
-    )
   }
 
   @objc func pressedExitButton() {

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -160,6 +160,12 @@ final class DebugViewController: UIViewController {
     initialLocaleIdentifier = Superwall.shared.options.localeIdentifier
     addSubviews()
     Task { await loadPreview() }
+    // Independent of the preview load on purpose. The picker is most useful
+    // precisely when the requested paywall fails to render — that is when you
+    // want to switch to another one — so it must not sit behind the preview's
+    // success path. Runs concurrently, and only here, so switching paywalls via
+    // the picker doesn't refetch a list that cannot have changed.
+    Task { await loadPreviewPaywalls() }
   }
 
   private func addSubviews() {
@@ -254,7 +260,6 @@ final class DebugViewController: UIViewController {
       self.previewPickerButton.setTitle("\(paywall.name)", for: .normal)
       self.activityIndicator.stopAnimating()
       self.addPaywallPreview()
-      await self.loadPreviewPaywalls()
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -317,10 +322,10 @@ final class DebugViewController: UIViewController {
   /// Populates the "Your Paywalls" picker from the application in the debugger's
   /// preview token.
   ///
-  /// Runs after the previewed paywall is on screen so the picker never delays
-  /// the thing the user actually asked for. Best-effort: a failure leaves
-  /// `previewPaywalls` empty and `pressedPreview` simply declines to open, which
-  /// is the behaviour before this was restored.
+  /// Kicked off from `viewDidLoad` alongside — not after — the preview load, so
+  /// the picker is available even when the requested paywall fails to render.
+  /// Best-effort: a failure leaves `previewPaywalls` empty and `pressedPreview`
+  /// declines to open, which is the behaviour before this was restored.
   private func loadPreviewPaywalls() async {
     do {
       let list = try await network.listPreviewPaywalls()

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -75,7 +75,7 @@ final class DebugViewController: UIViewController {
     return button
   }()
 
-  lazy var previewNameButton: SWBounceButton = {
+  lazy var previewPickerButton: SWBounceButton = {
     let button = SWBounceButton()
     button.setTitle("", for: .normal)
     button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
@@ -86,11 +86,14 @@ final class DebugViewController: UIViewController {
     button.setTitleColor(primaryColor, for: .normal)
     button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
     button.translatesAutoresizingMaskIntoConstraints = false
+    button.imageView?.tintColor = primaryColor
     button.layer.cornerRadius = 10
-    // Display-only chip showing the previewed paywall's name. The multi-paywall
-    // picker (a dropdown opened from this chip) was removed when the preview
-    // flow stopped fetching all paywalls, so it no longer responds to taps.
-    button.isUserInteractionEnabled = false
+
+    let image = UIImage(named: "SuperwallKit_down_arrow", in: Bundle.module, compatibleWith: nil)!
+    button.semanticContentAttribute = .forceRightToLeft
+    button.setImage(image, for: .normal)
+    button.imageView?.tintColor = primaryColor
+    button.addTarget(self, action: #selector(pressedPreview), for: .primaryActionTriggered)
     return button
   }()
 
@@ -108,12 +111,18 @@ final class DebugViewController: UIViewController {
     let button = SWBounceButton()
     button.shouldAnimateLightly = true
     button.translatesAutoresizingMaskIntoConstraints = false
+    button.addTarget(self, action: #selector(pressedPreview), for: .primaryActionTriggered)
     return button
   }()
 
   var paywallDatabaseId: String?
 	var paywallIdentifier: String?
   var paywall: Paywall?
+  /// Backs the "Your Paywalls" picker. Populated from
+  /// `GET /v2/paywalls/preview-list` (id/name/slug only — not the full paywalls
+  /// the pre-#3456 fetch-all returned). Empty when the request fails or the app
+  /// has a single paywall, in which case the picker declines to open.
+  var previewPaywalls: [PaywallPreviewListItem] = []
   var previewViewContent: UIView?
   private var cancellable: AnyCancellable?
   private var initialLocaleIdentifier: String?
@@ -160,7 +169,7 @@ final class DebugViewController: UIViewController {
     view.addSubview(consoleButton)
     view.addSubview(exitButton)
     view.addSubview(bottomButton)
-    previewContainerView.addSubview(previewNameButton)
+    previewContainerView.addSubview(previewPickerButton)
     view.backgroundColor = lightBackgroundColor
 
     previewContainerView.clipsToBounds = false
@@ -190,9 +199,9 @@ final class DebugViewController: UIViewController {
       bottomButton.widthAnchor.constraint(equalTo: view.layoutMarginsGuide.widthAnchor, constant: -40),
       bottomButton.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor, constant: -10),
 
-      previewNameButton.centerXAnchor.constraint(equalTo: previewContainerView.centerXAnchor, constant: 0),
-      previewNameButton.heightAnchor.constraint(equalToConstant: 26),
-      previewNameButton.centerYAnchor.constraint(equalTo: previewContainerView.bottomAnchor)
+      previewPickerButton.centerXAnchor.constraint(equalTo: previewContainerView.centerXAnchor, constant: 0),
+      previewPickerButton.heightAnchor.constraint(equalToConstant: 26),
+      previewPickerButton.centerYAnchor.constraint(equalTo: previewContainerView.bottomAnchor)
     ])
   }
 
@@ -242,9 +251,10 @@ final class DebugViewController: UIViewController {
       paywall.productVariables = productVariables
 
       self.paywall = paywall
-      self.previewNameButton.setTitle("\(paywall.name)", for: .normal)
+      self.previewPickerButton.setTitle("\(paywall.name)", for: .normal)
       self.activityIndicator.stopAnimating()
       self.addPaywallPreview()
+      await self.loadPreviewPaywalls()
     } catch {
       Logger.debug(
         logLevel: .error,
@@ -302,6 +312,63 @@ final class DebugViewController: UIViewController {
     ) {
       child.view.alpha = 1.0
     }
+  }
+
+  /// Populates the "Your Paywalls" picker from the application in the debugger's
+  /// preview token.
+  ///
+  /// Runs after the previewed paywall is on screen so the picker never delays
+  /// the thing the user actually asked for. Best-effort: a failure leaves
+  /// `previewPaywalls` empty and `pressedPreview` simply declines to open, which
+  /// is the behaviour before this was restored.
+  private func loadPreviewPaywalls() async {
+    do {
+      let list = try await network.listPreviewPaywalls()
+      previewPaywalls = list.data
+    } catch {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .debugViewController,
+        message: "Failed to Load Paywall Picker",
+        info: nil,
+        error: error
+      )
+    }
+  }
+
+  @objc func pressedPreview() {
+    guard let id = paywallDatabaseId else { return }
+
+    // Empty when the list request failed. Single-entry when the app has one
+    // paywall — an action sheet offering only what's already on screen is noise,
+    // so bail rather than present it.
+    guard previewPaywalls.count > 1 else { return }
+
+    let options: [AlertOption] = previewPaywalls.map { paywall in
+      var name = paywall.name
+
+      if id == paywall.id {
+        name = "\(name) ✓"
+      }
+
+      let alert = AlertOption(
+        title: name,
+        action: { [weak self] in
+          self?.paywallDatabaseId = paywall.id
+          self?.paywallIdentifier = paywall.identifier
+          Task { await self?.loadPreview() }
+        },
+        style: .default
+      )
+      return alert
+    }
+
+    presentAlert(
+      title: nil,
+      message: "Your Paywalls",
+      options: options,
+      on: previewPickerButton
+    )
   }
 
   @objc func pressedExitButton() {

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -118,11 +118,11 @@ final class DebugViewController: UIViewController {
   var paywallDatabaseId: String?
 	var paywallIdentifier: String?
   var paywall: Paywall?
-  /// Backs the "Your Paywalls" picker. Populated from
-  /// `GET /v2/paywalls/preview-list` (id/name/slug only — not the full paywalls
-  /// the pre-#3456 fetch-all returned). Empty when the request fails or the app
+  /// Backs the "Your Paywalls" picker.
+  ///
+  /// Populated from `GET /v2/paywalls/preview-list`. Empty when the request fails or the app
   /// has a single paywall, in which case the picker declines to open.
-  var previewPaywalls: [PaywallPreviewListItem] = []
+  var previewPaywalls: [PaywallSummary] = []
   var previewViewContent: UIView?
   private var cancellable: AnyCancellable?
   private var initialLocaleIdentifier: String?
@@ -160,11 +160,6 @@ final class DebugViewController: UIViewController {
     initialLocaleIdentifier = Superwall.shared.options.localeIdentifier
     addSubviews()
     Task { await loadPreview() }
-    // Independent of the preview load on purpose. The picker is most useful
-    // precisely when the requested paywall fails to render — that is when you
-    // want to switch to another one — so it must not sit behind the preview's
-    // success path. Runs concurrently, and only here, so switching paywalls via
-    // the picker doesn't refetch a list that cannot have changed.
     Task { await loadPreviewPaywalls() }
   }
 
@@ -224,8 +219,7 @@ final class DebugViewController: UIViewController {
 			paywallId = paywallIdentifier
 		} else if let paywallDatabaseId = paywallDatabaseId {
       // Resolve the numeric database id from the deep link to the paywall's
-      // identifier (slug) with a single lookup, rather than fetching every
-      // paywall for the app and filtering in memory.
+      // identifier (slug) with a single lookup.
       do {
         let resolution = try await network.resolvePaywallIdentifier(forDatabaseId: paywallDatabaseId)
         paywallId = resolution.identifier

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -342,17 +342,19 @@ final class DebugViewController: UIViewController {
   }
 
   @objc func pressedPreview() {
-    guard let id = paywallDatabaseId else { return }
-
-    // Empty when the list request failed. Single-entry when the app has one
-    // paywall — an action sheet offering only what's already on screen is noise,
-    // so bail rather than present it.
-    guard previewPaywalls.count > 1 else { return }
+    // Open whenever there is something to switch *to*. That covers an empty list
+    // (the request failed) and a single-entry list whose one paywall is already
+    // on screen, without gating on `paywallDatabaseId` — which is nil when the
+    // deep link carried no `paywall_id` and nothing rendered. That is precisely
+    // when the picker is most useful, so it must not be inert then.
+    guard previewPaywalls.contains(where: { $0.id != paywallDatabaseId }) else { return }
 
     let options: [AlertOption] = previewPaywalls.map { paywall in
       var name = paywall.name
 
-      if id == paywall.id {
+      // Optional comparison: with no paywall on screen nothing is marked, which
+      // is correct rather than a case to guard against.
+      if paywall.id == paywallDatabaseId {
         name = "\(name) ✓"
       }
 

--- a/Sources/SuperwallKit/Debug/SWBounceButton.swift
+++ b/Sources/SuperwallKit/Debug/SWBounceButton.swift
@@ -27,8 +27,17 @@ final class SWBounceButton: UIButton {
         self.activityIndicator.startAnimating()
         self.isEnabled = false
       } else {
-        self.setTitle(oldTitle, for: .normal)
-        self.oldTitle = ""
+        // `didSet` fires on every assignment, not just on a change, so
+        // `showLoading = false` can arrive when loading was never started (or
+        // was already ended). `oldTitle` is empty in that case, and restoring
+        // it unconditionally would blank a perfectly good title — e.g. the
+        // debugger's "Preview" button vanishes when a second terminal state
+        // (skipped, then presentationError) lands on an already-idle button.
+        // Only restore when there is a saved title to restore.
+        if !oldTitle.isEmpty {
+          self.setTitle(oldTitle, for: .normal)
+          self.oldTitle = ""
+        }
         self.activityIndicator.stopAnimating()
         self.isEnabled = true
       }

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -52,14 +52,15 @@ struct PaywallPreviewListItem: Decodable {
 /// preview token, so the picker can offer alternatives without fetching every
 /// paywall in full. Deliberately carries no presentable paywall JSON.
 ///
-/// Decoded with `JSONDecoder.fromSnakeCase`; the endpoint also returns `object`
-/// and `application_id`, which are not needed here and are ignored.
+/// Decoded with `JSONDecoder.fromSnakeCase`. The endpoint also returns `object`,
+/// `has_more` and `application_id`; none are decoded here. `has_more` in
+/// particular is deliberately omitted rather than declared and ignored — the
+/// picker does not paginate, and a non-optional field nothing reads would turn
+/// any future change in the response shape into a `keyNotFound` that empties the
+/// whole picker.
 struct PaywallPreviewList: Decodable {
   /// The paywalls available to preview, capped server-side.
   let data: [PaywallPreviewListItem]
-
-  /// True when the application has more paywalls than the returned cap.
-  let hasMore: Bool
 }
 
 struct Paywall: Codable {

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -29,6 +29,39 @@ struct PaywallIdentifierResolution: Decodable {
   let name: String
 }
 
+/// One row of the debugger's paywall picker, from
+/// `GET /v2/paywalls/preview-list`.
+///
+/// Structurally identical to ``PaywallIdentifierResolution`` — the picker needs
+/// exactly what the resolver returns, for every paywall in the application
+/// rather than one. Kept as its own type so the two endpoints can diverge.
+struct PaywallPreviewListItem: Decodable {
+  /// The id of the paywall in the database.
+  let id: String
+
+  /// The identifier (slug) of the paywall, used to fetch the full paywall.
+  let identifier: String
+
+  /// The display name of the paywall.
+  let name: String
+}
+
+/// The response from `GET /v2/paywalls/preview-list`.
+///
+/// Lists the non-archived paywalls of the application in the debugger's `sat_`
+/// preview token, so the picker can offer alternatives without fetching every
+/// paywall in full. Deliberately carries no presentable paywall JSON.
+///
+/// Decoded with `JSONDecoder.fromSnakeCase`; the endpoint also returns `object`
+/// and `application_id`, which are not needed here and are ignored.
+struct PaywallPreviewList: Decodable {
+  /// The paywalls available to preview, capped server-side.
+  let data: [PaywallPreviewListItem]
+
+  /// True when the application has more paywalls than the returned cap.
+  let hasMore: Bool
+}
+
 struct Paywall: Codable {
   /// The id of the paywall in the database.
   var databaseId: String

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -8,61 +8,6 @@
 
 import UIKit
 
-/// The minimal paywall metadata returned by the V2 resolver endpoint
-/// (`GET /v2/paywalls/resolve`).
-///
-/// The debug/preview deep link carries a numeric paywall database `id`, but the
-/// full-paywall fetch is keyed by `identifier` (slug). This lets the preview
-/// flow translate `id` → `identifier` with a single lookup instead of fetching
-/// every paywall for the app.
-///
-/// Decoded with `JSONDecoder.fromSnakeCase`; the endpoint also returns
-/// `application_id`, which is not needed here and is ignored.
-struct PaywallIdentifierResolution: Decodable {
-  /// The id of the paywall in the database.
-  let id: String
-
-  /// The identifier (slug) of the paywall, used to fetch the full paywall.
-  let identifier: String
-
-  /// The display name of the paywall.
-  let name: String
-}
-
-/// One row of the debugger's paywall picker, from
-/// `GET /v2/paywalls/preview-list`.
-///
-/// Structurally identical to ``PaywallIdentifierResolution`` — the picker needs
-/// exactly what the resolver returns, for every paywall in the application
-/// rather than one. Kept as its own type so the two endpoints can diverge.
-struct PaywallPreviewListItem: Decodable {
-  /// The id of the paywall in the database.
-  let id: String
-
-  /// The identifier (slug) of the paywall, used to fetch the full paywall.
-  let identifier: String
-
-  /// The display name of the paywall.
-  let name: String
-}
-
-/// The response from `GET /v2/paywalls/preview-list`.
-///
-/// Lists the non-archived paywalls of the application in the debugger's `sat_`
-/// preview token, so the picker can offer alternatives without fetching every
-/// paywall in full. Deliberately carries no presentable paywall JSON.
-///
-/// Decoded with `JSONDecoder.fromSnakeCase`. The endpoint also returns `object`,
-/// `has_more` and `application_id`; none are decoded here. `has_more` in
-/// particular is deliberately omitted rather than declared and ignored — the
-/// picker does not paginate, and a non-optional field nothing reads would turn
-/// any future change in the response shape into a `keyNotFound` that empties the
-/// whole picker.
-struct PaywallPreviewList: Decodable {
-  /// The paywalls available to preview, capped server-side.
-  let data: [PaywallPreviewListItem]
-}
-
 struct Paywall: Codable {
   /// The id of the paywall in the database.
   var databaseId: String

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -8,8 +8,25 @@
 
 import UIKit
 
-struct Paywalls: Decodable {
-  var paywalls: [Paywall]
+/// The minimal paywall metadata returned by the V2 resolver endpoint
+/// (`GET /v2/paywalls/resolve`).
+///
+/// The debug/preview deep link carries a numeric paywall database `id`, but the
+/// full-paywall fetch is keyed by `identifier` (slug). This lets the preview
+/// flow translate `id` → `identifier` with a single lookup instead of fetching
+/// every paywall for the app.
+///
+/// Decoded with `JSONDecoder.fromSnakeCase`; the endpoint also returns
+/// `application_id`, which is not needed here and is ignored.
+struct PaywallIdentifierResolution: Decodable {
+  /// The id of the paywall in the database.
+  let id: String
+
+  /// The identifier (slug) of the paywall, used to fetch the full paywall.
+  let identifier: String
+
+  /// The display name of the paywall.
+  let name: String
 }
 
 struct Paywall: Codable {

--- a/Sources/SuperwallKit/Models/Paywall/PaywallPreviewList.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallPreviewList.swift
@@ -1,0 +1,14 @@
+//
+//  PaywallPreviewList.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 30/07/2026.
+//
+
+import Foundation
+
+/// The response from `GET /v2/paywalls/preview-list`.
+struct PaywallPreviewList: Decodable {
+  /// The paywalls available to preview, capped server-side.
+  let data: [PaywallSummary]
+}

--- a/Sources/SuperwallKit/Models/Paywall/PaywallSummary.swift
+++ b/Sources/SuperwallKit/Models/Paywall/PaywallSummary.swift
@@ -1,0 +1,21 @@
+//
+//  PaywallSummary.swift
+//  SuperwallKit
+//
+//  Created by Yusuf Tör on 30/07/2026.
+//
+
+import Foundation
+
+/// The minimal paywall metadata the debug/preview flow needs: enough to fetch
+/// and label a paywall.
+struct PaywallSummary: Decodable {
+  /// The id of the paywall in the database.
+  let id: String
+
+  /// The identifier (slug) of the paywall, used to fetch the full paywall.
+  let identifier: String
+
+  /// The display name of the paywall.
+  let name: String
+}

--- a/Sources/SuperwallKit/Network/API.swift
+++ b/Sources/SuperwallKit/Network/API.swift
@@ -120,11 +120,12 @@ struct Api {
     }
   }
 
-  /// The V2 API served under the `/v2/` prefix on the base host
-  /// (e.g. `superwall.com/v2/*`, which is routed to the V2 Worker).
+  /// The Superwall V2 API, served under a `/v2/` path on `api.superwall.com`
+  /// (production) / `api.superwall.dev` (developer). See
+  /// `NetworkEnvironment.apiV2Host`.
   struct PaywallsV2: ApiHostConfig {
     let networkEnvironment: SuperwallOptions.NetworkEnvironment
-    var host: String { return networkEnvironment.baseHost }
+    var host: String { return networkEnvironment.apiV2Host }
     var path: String { return "/v2/" }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {

--- a/Sources/SuperwallKit/Network/API.swift
+++ b/Sources/SuperwallKit/Network/API.swift
@@ -13,6 +13,7 @@ enum EndpointHost {
   case enrichment
   case adServices
   case subscriptionsApi
+  case paywallsV2
 }
 
 protocol ApiHostConfig {
@@ -34,6 +35,7 @@ struct Api {
   let enrichment: Enrichment
   let adServices: AdServices
   let subscriptionsApi: SubscriptionsAPI
+  let paywallsV2: PaywallsV2
 
   init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
     base = Base(networkEnvironment: networkEnvironment)
@@ -41,6 +43,7 @@ struct Api {
     enrichment = Enrichment(networkEnvironment: networkEnvironment)
     adServices = AdServices(networkEnvironment: networkEnvironment)
     subscriptionsApi = SubscriptionsAPI(networkEnvironment: networkEnvironment)
+    paywallsV2 = PaywallsV2(networkEnvironment: networkEnvironment)
   }
 
   func getConfig(host: EndpointHost) -> ApiHostConfig {
@@ -55,6 +58,8 @@ struct Api {
       return adServices
     case .subscriptionsApi:
       return subscriptionsApi
+    case .paywallsV2:
+      return paywallsV2
     }
   }
 
@@ -104,6 +109,18 @@ struct Api {
     let networkEnvironment: SuperwallOptions.NetworkEnvironment
     var host: String { return networkEnvironment.web2AppHost }
     var path: String { return "/subscriptions-api/public/v1/" }
+
+    init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
+      self.networkEnvironment = networkEnvironment
+    }
+  }
+
+  /// The V2 API served under the `/v2/` prefix on the base host
+  /// (e.g. `superwall.com/v2/*`, which is routed to the V2 Worker).
+  struct PaywallsV2: ApiHostConfig {
+    let networkEnvironment: SuperwallOptions.NetworkEnvironment
+    var host: String { return networkEnvironment.baseHost }
+    var path: String { return "/v2/" }
 
     init(networkEnvironment: SuperwallOptions.NetworkEnvironment) {
       self.networkEnvironment = networkEnvironment

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -216,7 +216,9 @@ extension Endpoint where
   ///
   /// Used by the debug/preview flow so it no longer has to fetch every paywall
   /// for the app just to translate a deep-link `paywall_id` into an identifier.
-  /// Authenticated with the app's public key (see `Network.resolvePaywallIdentifier`).
+  /// Authenticated with the debugger's signed preview token (the `sat_` token
+  /// from the deeplink, sent as `Authorization: Bearer <debugKey>`), not the
+  /// app's public key (see `Network.resolvePaywallIdentifier`).
   static func resolvePaywall(
     byDatabaseId databaseId: String,
     retryCount: Int

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -207,15 +207,26 @@ extension Endpoint where
   }
 }
 
-// MARK: - PaywallsResponse
+// MARK: - PaywallIdentifierResolution
 extension Endpoint where
   Kind == EndpointKinds.Superwall,
-  Response == Paywalls {
-  static func paywalls() -> Self {
+  Response == PaywallIdentifierResolution {
+  /// Resolves a numeric paywall database id to its identifier (slug) via the V2
+  /// resolver endpoint (`GET /v2/paywalls/resolve?id=<id>`).
+  ///
+  /// Used by the debug/preview flow so it no longer has to fetch every paywall
+  /// for the app just to translate a deep-link `paywall_id` into an identifier.
+  /// Authenticated with the app's public key (see `Network.resolvePaywallIdentifier`).
+  static func resolvePaywall(
+    byDatabaseId databaseId: String,
+    retryCount: Int
+  ) -> Self {
     return Endpoint(
+      retryCount: retryCount,
       components: Components(
-        host: .base,
-        path: "paywalls"
+        host: .paywallsV2,
+        path: "paywalls/resolve",
+        queryItems: [URLQueryItem(name: "id", value: databaseId)]
       ),
       method: .get
     )

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -207,18 +207,14 @@ extension Endpoint where
   }
 }
 
-// MARK: - PaywallIdentifierResolution
+// MARK: - PaywallSummary
 extension Endpoint where
   Kind == EndpointKinds.Superwall,
-  Response == PaywallIdentifierResolution {
-  /// Resolves a numeric paywall database id to its identifier (slug) via the V2
-  /// resolver endpoint (`GET /v2/paywalls/resolve?id=<id>`).
+  Response == PaywallSummary {
+  /// Resolves a numeric paywall database id to its identifier (slug).
   ///
   /// Used by the debug/preview flow so it no longer has to fetch every paywall
   /// for the app just to translate a deep-link `paywall_id` into an identifier.
-  /// Authenticated with the debugger's signed preview token (the `sat_` token
-  /// from the deeplink, sent as `Authorization: Bearer <debugKey>`), not the
-  /// app's public key (see `Network.resolvePaywallIdentifier`).
   static func resolvePaywall(
     byDatabaseId databaseId: String,
     retryCount: Int
@@ -240,14 +236,10 @@ extension Endpoint where
   Kind == EndpointKinds.Superwall,
   Response == PaywallPreviewList {
   /// Lists the paywalls available to preview for the application in the
-  /// debugger's signed preview token (`GET /v2/paywalls/preview-list`).
+  /// debugger's signed preview token.
   ///
   /// Backs the debugger's "Your Paywalls" picker. Returns id/identifier/name
-  /// only — never the presentable paywall JSON — so switching previews costs one
-  /// small request rather than the fetch-all this replaced.
-  ///
-  /// Same auth as `resolvePaywall`: the `sat_` token from the deeplink, sent as
-  /// `Authorization: Bearer <debugKey>` (see `Network.listPreviewPaywalls`).
+  /// only.
   static func listPreviewPaywalls(retryCount: Int) -> Self {
     return Endpoint(
       retryCount: retryCount,

--- a/Sources/SuperwallKit/Network/Endpoint.swift
+++ b/Sources/SuperwallKit/Network/Endpoint.swift
@@ -235,6 +235,31 @@ extension Endpoint where
   }
 }
 
+// MARK: - PaywallPreviewList
+extension Endpoint where
+  Kind == EndpointKinds.Superwall,
+  Response == PaywallPreviewList {
+  /// Lists the paywalls available to preview for the application in the
+  /// debugger's signed preview token (`GET /v2/paywalls/preview-list`).
+  ///
+  /// Backs the debugger's "Your Paywalls" picker. Returns id/identifier/name
+  /// only — never the presentable paywall JSON — so switching previews costs one
+  /// small request rather than the fetch-all this replaced.
+  ///
+  /// Same auth as `resolvePaywall`: the `sat_` token from the deeplink, sent as
+  /// `Authorization: Bearer <debugKey>` (see `Network.listPreviewPaywalls`).
+  static func listPreviewPaywalls(retryCount: Int) -> Self {
+    return Endpoint(
+      retryCount: retryCount,
+      components: Components(
+        host: .paywallsV2,
+        path: "paywalls/preview-list"
+      ),
+      method: .get
+    )
+  }
+}
+
 // MARK: - ConfigResponse
 extension Endpoint where
   Kind == EndpointKinds.Superwall,

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -124,15 +124,10 @@ class Network {
 
   /// Resolves a numeric paywall database id to its identifier (slug) so the
   /// debug/preview flow can fetch a single paywall instead of all of them.
-  ///
-  /// Authenticated with the debugger's signed preview token (the `sat_` token
-  /// from the debugger deeplink, stored in `storage.debugKey`) via
-  /// `isForDebugging: true`, which `makeHeaders` sends as
-  /// `Authorization: Bearer <debugKey>` — not the app's public key.
   func resolvePaywallIdentifier(
     forDatabaseId databaseId: String,
     retryCount: Int = 6
-  ) async throws -> PaywallIdentifierResolution {
+  ) async throws -> PaywallSummary {
     do {
       return try await urlSession.request(
         .resolvePaywall(
@@ -157,10 +152,6 @@ class Network {
 
   /// Lists the paywalls available to preview for the application in the
   /// debugger's signed preview token, backing the debugger's paywall picker.
-  ///
-  /// Same auth as ``resolvePaywallIdentifier(forDatabaseId:retryCount:)``: the
-  /// `sat_` token from the debugger deeplink (stored in `storage.debugKey`) via
-  /// `isForDebugging: true`, not the app's public key.
   ///
   /// Retries less than the resolver: this only populates an optional picker, so
   /// a failure should degrade to "no alternatives to offer" quickly rather than

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -125,8 +125,10 @@ class Network {
   /// Resolves a numeric paywall database id to its identifier (slug) so the
   /// debug/preview flow can fetch a single paywall instead of all of them.
   ///
-  /// Authenticated with the app's public key (`isForDebugging: false`), which
-  /// `makeHeaders` sends as `Authorization: Bearer <apiKey>`.
+  /// Authenticated with the debugger's signed preview token (the `sat_` token
+  /// from the debugger deeplink, stored in `storage.debugKey`) via
+  /// `isForDebugging: true`, which `makeHeaders` sends as
+  /// `Authorization: Bearer <debugKey>` — not the app's public key.
   func resolvePaywallIdentifier(
     forDatabaseId databaseId: String,
     retryCount: Int = 6
@@ -139,7 +141,7 @@ class Network {
         ),
         data: SuperwallRequestData(
           factory: factory,
-          isForDebugging: false
+          isForDebugging: true
         )
       )
     } catch {

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -155,6 +155,36 @@ class Network {
     }
   }
 
+  /// Lists the paywalls available to preview for the application in the
+  /// debugger's signed preview token, backing the debugger's paywall picker.
+  ///
+  /// Same auth as ``resolvePaywallIdentifier(forDatabaseId:retryCount:)``: the
+  /// `sat_` token from the debugger deeplink (stored in `storage.debugKey`) via
+  /// `isForDebugging: true`, not the app's public key.
+  ///
+  /// Retries less than the resolver: this only populates an optional picker, so
+  /// a failure should degrade to "no alternatives to offer" quickly rather than
+  /// hold the debugger up.
+  func listPreviewPaywalls(retryCount: Int = 2) async throws -> PaywallPreviewList {
+    do {
+      return try await urlSession.request(
+        .listPreviewPaywalls(retryCount: retryCount),
+        data: SuperwallRequestData(
+          factory: factory,
+          isForDebugging: true
+        )
+      )
+    } catch {
+      Logger.debug(
+        logLevel: .error,
+        scope: .network,
+        message: "Request Failed: /v2/paywalls/preview-list",
+        error: error
+      )
+      throw error
+    }
+  }
+
   func getConfig(
     injectedApplicationStatePublisher: (AnyPublisher<UIApplication.State, Never>)? = nil,
     maxRetry: Int? = nil,

--- a/Sources/SuperwallKit/Network/Network.swift
+++ b/Sources/SuperwallKit/Network/Network.swift
@@ -122,21 +122,31 @@ class Network {
     }
   }
 
-  func getPaywalls() async throws -> [Paywall] {
+  /// Resolves a numeric paywall database id to its identifier (slug) so the
+  /// debug/preview flow can fetch a single paywall instead of all of them.
+  ///
+  /// Authenticated with the app's public key (`isForDebugging: false`), which
+  /// `makeHeaders` sends as `Authorization: Bearer <apiKey>`.
+  func resolvePaywallIdentifier(
+    forDatabaseId databaseId: String,
+    retryCount: Int = 6
+  ) async throws -> PaywallIdentifierResolution {
     do {
-      let response = try await urlSession.request(
-        .paywalls(),
+      return try await urlSession.request(
+        .resolvePaywall(
+          byDatabaseId: databaseId,
+          retryCount: retryCount
+        ),
         data: SuperwallRequestData(
           factory: factory,
-          isForDebugging: true
+          isForDebugging: false
         )
       )
-      return response.paywalls
     } catch {
       Logger.debug(
         logLevel: .error,
         scope: .network,
-        message: "Request Failed: /paywalls",
+        message: "Request Failed: /v2/paywalls/resolve",
         error: error
       )
       throw error

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 		DCE85B4A9DBD672B658F6EB3 /* MockSKPaymentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1A6ADFFB9FA982BF69C134 /* MockSKPaymentTransaction.swift */; };
 		DE2F41FF9D70AB13AD246E49 /* VariantOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194B8214C0A66407CEDCC0F4 /* VariantOption.swift */; };
 		DE62F8E261EC7C60FBAAAE1D /* BundleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34468E3988E779132CE101A /* BundleHelper.swift */; };
+		DEA127FF77AC2E0645E5D4A8 /* PaywallPreviewList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570D9BC01DCF5BA4DB7F95AA /* PaywallPreviewList.swift */; };
 		DEB255607E961730B4A5761B /* UIDevice+ModelName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750CC308DD48F4CE615DFC89 /* UIDevice+ModelName.swift */; };
 		DEBEE747AFE84B9F7D1ABB52 /* StoreProductAdapterObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D054D402A5F820BB3D18D8AC /* StoreProductAdapterObjc.swift */; };
 		DEF83BEF1ED06921BD55F55A /* EvaluationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07DC8EA2AB02423AEE5DF26 /* EvaluationContext.swift */; };
@@ -531,6 +532,7 @@
 		ED1C693657DA7FCBAE2DDDC6 /* FeatureGatingBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B8D7F537204EAB13BB7F10 /* FeatureGatingBehaviour.swift */; };
 		ED246150DA2747AA42D6009C /* PermissionStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988E0E3F8D992744C9AC196F /* PermissionStatusTests.swift */; };
 		ED575DD46B84EE351972AC6B /* AdServicesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B4279B992779CAD5A0694A /* AdServicesResponse.swift */; };
+		ED66539CDB2C991A812A6CC7 /* PaywallSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12EB4944354482783293010 /* PaywallSummary.swift */; };
 		EDAEC46845C1DB11CB4C99AE /* SWConsoleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDFBF0FA8B313E0D84A51DB /* SWConsoleViewController.swift */; };
 		EE5646D09161237C649731F4 /* SWWebViewLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2AC9214EA750436EF1FE11 /* SWWebViewLogicTests.swift */; };
 		F0013E500B7F2113857F8161 /* NotificationSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F4CF06DE50031C329ED96F /* NotificationSchedulerTests.swift */; };
@@ -771,6 +773,7 @@
 		544C032167E8198513B2A860 /* PresentationValueObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationValueObjc.swift; sourceTree = "<group>"; };
 		5664E123CF093BFF557741E1 /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = hi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		56B6A546564CE1CB37BDC6A0 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
+		570D9BC01DCF5BA4DB7F95AA /* PaywallPreviewList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPreviewList.swift; sourceTree = "<group>"; };
 		571825E7515FCC1E877D4429 /* Dictionary+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Cache.swift"; sourceTree = "<group>"; };
 		57478172574516BD5EDD254A /* LoadingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingInfo.swift; sourceTree = "<group>"; };
 		577A16EE2161E2CDEDFA48C0 /* GameControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerManager.swift; sourceTree = "<group>"; };
@@ -957,6 +960,7 @@
 		A08CC3D275A02927073952EB /* ReceiptManagerTrialEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManagerTrialEligibilityTests.swift; sourceTree = "<group>"; };
 		A0B4279B992779CAD5A0694A /* AdServicesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdServicesResponse.swift; sourceTree = "<group>"; };
 		A116633D7246EB7BB7AF7229 /* ExpressionEvaluatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorMock.swift; sourceTree = "<group>"; };
+		A12EB4944354482783293010 /* PaywallSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallSummary.swift; sourceTree = "<group>"; };
 		A154A9E99D00B9BD8837B798 /* ExpressionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionLogic.swift; sourceTree = "<group>"; };
 		A21ED2D8CB4DDA70E228E8BC /* TaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskExecutor.swift; sourceTree = "<group>"; };
 		A22E703895B07CF172665846 /* PaywallLoadingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLoadingState.swift; sourceTree = "<group>"; };
@@ -1225,8 +1229,10 @@
 				82E6981E6A6574EE72B65A9E /* Paywall.swift */,
 				C65CEB049E29538C699F6EF8 /* PaywallPresentationInfo.swift */,
 				153C660FB51D0D1DFE56D462 /* PaywallPresentationStyle.swift */,
+				570D9BC01DCF5BA4DB7F95AA /* PaywallPreviewList.swift */,
 				0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */,
 				B6F71D7A7DC8FFB72CA13296 /* PaywallRequestBody.swift */,
+				A12EB4944354482783293010 /* PaywallSummary.swift */,
 				22439CFFFC5166F34D0DA524 /* WebViewURLConfig.swift */,
 				10B0008D7CD157DA0F7B6D54 /* Archive */,
 			);
@@ -3582,12 +3588,14 @@
 				953BB5825DA956E4BBE841B9 /* PaywallPresentationInfo.swift in Sources */,
 				1BA9EC022F0016E72A5EB01A /* PaywallPresentationRequestStatus.swift in Sources */,
 				A2DC9FA3045DF056BC867D8B /* PaywallPresentationStyle.swift in Sources */,
+				DEA127FF77AC2E0645E5D4A8 /* PaywallPreviewList.swift in Sources */,
 				CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */,
 				8EC4001F5273FB1260618E84 /* PaywallRequest.swift in Sources */,
 				D461F38D019122194A9CB38C /* PaywallRequestBody.swift in Sources */,
 				BFBE808BCA151FAE95AE3276 /* PaywallRequestManager.swift in Sources */,
 				62F714EC324D4BFCB3DF1CA9 /* PaywallSkippedReason.swift in Sources */,
 				00BC6BCF58320BFAC95E7B5F /* PaywallState.swift in Sources */,
+				ED66539CDB2C991A812A6CC7 /* PaywallSummary.swift in Sources */,
 				C8671043E6585DE19AAD1DAD /* PaywallView.swift in Sources */,
 				00A15C51FC3B450A7B0F8806 /* PaywallViewController.swift in Sources */,
 				D56F32CB484F74EC7E49E581 /* PaywallViewControllerCache.swift in Sources */,

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -204,4 +204,78 @@ struct NetworkTests {
     // `sat_` debug key as a bearer token, not the app's public key.
     #expect(urlRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer sat_test")
   }
+
+  @Test func listPreviewPaywalls_endpointBuildsRequest() async throws {
+    let dependencyContainer = DependencyContainer()
+    dependencyContainer.storage.debugKey = "sat_test"
+    let endpoint = Endpoint<EndpointKinds.Superwall, PaywallPreviewList>.listPreviewPaywalls(
+      retryCount: 2
+    )
+
+    let urlRequest = await endpoint.makeRequest(
+      with: SuperwallRequestData(factory: dependencyContainer, isForDebugging: true),
+      factory: dependencyContainer
+    )
+
+    #expect(urlRequest?.httpMethod == "GET")
+
+    let urlString = try #require(urlRequest?.url?.absoluteString)
+    #expect(urlString.contains("/v2/paywalls/preview-list"))
+
+    // The application comes from the token's scope server-side, so the picker
+    // must not be sending an id or application_id of its own.
+    #expect(urlString.contains("?") == false)
+
+    // Same auth as the resolver: the debugger's `sat_` preview token as a
+    // bearer, not the app's public key.
+    #expect(urlRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer sat_test")
+  }
+
+  @Test func paywallPreviewList_decodesIgnoringUndeclaredFields() throws {
+    // `object`, `has_more` and `application_id` are returned by the endpoint but
+    // deliberately not declared on the model. Decoding must ignore them rather
+    // than throw, so a change to those fields can never empty the picker.
+    let json = """
+    {
+      "object": "list",
+      "has_more": false,
+      "application_id": "2889",
+      "data": [
+        { "id": "178725", "identifier": "some-slug", "name": "Some Paywall" }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    let list = try JSONDecoder.fromSnakeCase.decode(PaywallPreviewList.self, from: json)
+
+    #expect(list.data.count == 1)
+    #expect(list.data.first?.id == "178725")
+    #expect(list.data.first?.identifier == "some-slug")
+    #expect(list.data.first?.name == "Some Paywall")
+  }
+
+  @Test func paywallPreviewList_decodesWhenUndeclaredFieldsAbsent() throws {
+    // The inverse: `data` alone must decode, so the picker survives the endpoint
+    // dropping fields the SDK never reads.
+    let json = """
+    { "data": [{ "id": "1", "identifier": "s", "name": "N" }] }
+    """.data(using: .utf8)!
+
+    let list = try JSONDecoder.fromSnakeCase.decode(PaywallPreviewList.self, from: json)
+
+    #expect(list.data.count == 1)
+  }
+
+  @Test func paywallPreviewList_decodesEmptyList() throws {
+    // An app with no previewable paywalls returns an empty `data`. That must
+    // decode cleanly — `pressedPreview` then declines to open the picker rather
+    // than the request being treated as a failure.
+    let json = """
+    { "object": "list", "has_more": false, "data": [] }
+    """.data(using: .utf8)!
+
+    let list = try JSONDecoder.fromSnakeCase.decode(PaywallPreviewList.self, from: json)
+
+    #expect(list.data.isEmpty)
+  }
 }

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -183,7 +183,7 @@ struct NetworkTests {
   @Test func resolvePaywall_endpointBuildsRequest() async throws {
     let dependencyContainer = DependencyContainer()
     dependencyContainer.storage.debugKey = "sat_test"
-    let endpoint = Endpoint<EndpointKinds.Superwall, PaywallIdentifierResolution>.resolvePaywall(
+    let endpoint = Endpoint<EndpointKinds.Superwall, PaywallSummary>.resolvePaywall(
       byDatabaseId: "123",
       retryCount: 6
     )

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -196,7 +196,10 @@ struct NetworkTests {
     #expect(urlRequest?.httpMethod == "GET")
 
     let urlString = try #require(urlRequest?.url?.absoluteString)
-    #expect(urlString.contains("/v2/paywalls/resolve"))
+    // Host and path asserted together: matching the path alone passes whichever
+    // host the endpoint resolved to, which is how the V2 resolver shipped
+    // pointing at the v1 `baseHost` (fixed in b073dda).
+    #expect(urlString.contains("api.superwall.com/v2/paywalls/resolve"))
     #expect(urlString.contains("id=123"))
 
     // The resolver authenticates with the debugger's signed preview token
@@ -220,7 +223,9 @@ struct NetworkTests {
     #expect(urlRequest?.httpMethod == "GET")
 
     let urlString = try #require(urlRequest?.url?.absoluteString)
-    #expect(urlString.contains("/v2/paywalls/preview-list"))
+    // Host included for the same reason as the resolver's test: the path alone
+    // would pass against the v1 `baseHost`.
+    #expect(urlString.contains("api.superwall.com/v2/paywalls/preview-list"))
 
     // The application comes from the token's scope server-side, so the picker
     // must not be sending an id or application_id of its own.

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -179,4 +179,27 @@ struct NetworkTests {
     #expect(bodyJson["deviceId"] as? String == "device_123")
     #expect(bodyJson["appUserId"] as? String == "user_123")
   }
+
+  @Test func resolvePaywall_endpointBuildsRequest() async throws {
+    let dependencyContainer = DependencyContainer()
+    let endpoint = Endpoint<EndpointKinds.Superwall, PaywallIdentifierResolution>.resolvePaywall(
+      byDatabaseId: "123",
+      retryCount: 6
+    )
+
+    let urlRequest = await endpoint.makeRequest(
+      with: SuperwallRequestData(factory: dependencyContainer, isForDebugging: false),
+      factory: dependencyContainer
+    )
+
+    #expect(urlRequest?.httpMethod == "GET")
+
+    let urlString = try #require(urlRequest?.url?.absoluteString)
+    #expect(urlString.contains("/v2/paywalls/resolve"))
+    #expect(urlString.contains("id=123"))
+
+    // The resolver authenticates with the public key (isForDebugging: false),
+    // so an Authorization header is attached.
+    #expect(urlRequest?.value(forHTTPHeaderField: "Authorization") != nil)
+  }
 }

--- a/Tests/SuperwallKitTests/Network/NetworkTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkTests.swift
@@ -182,13 +182,14 @@ struct NetworkTests {
 
   @Test func resolvePaywall_endpointBuildsRequest() async throws {
     let dependencyContainer = DependencyContainer()
+    dependencyContainer.storage.debugKey = "sat_test"
     let endpoint = Endpoint<EndpointKinds.Superwall, PaywallIdentifierResolution>.resolvePaywall(
       byDatabaseId: "123",
       retryCount: 6
     )
 
     let urlRequest = await endpoint.makeRequest(
-      with: SuperwallRequestData(factory: dependencyContainer, isForDebugging: false),
+      with: SuperwallRequestData(factory: dependencyContainer, isForDebugging: true),
       factory: dependencyContainer
     )
 
@@ -198,8 +199,9 @@ struct NetworkTests {
     #expect(urlString.contains("/v2/paywalls/resolve"))
     #expect(urlString.contains("id=123"))
 
-    // The resolver authenticates with the public key (isForDebugging: false),
-    // so an Authorization header is attached.
-    #expect(urlRequest?.value(forHTTPHeaderField: "Authorization") != nil)
+    // The resolver authenticates with the debugger's signed preview token
+    // (isForDebugging: true), so the Authorization header carries the
+    // `sat_` debug key as a bearer token, not the app's public key.
+    #expect(urlRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer sat_test")
   }
 }


### PR DESCRIPTION
## Problem

The debug/preview flow (open one paywall via a dashboard QR / deep link) fetches **ALL** paywalls for the app (`GET /api/v1/paywalls`) just to translate the deep-link numeric `paywall_id` (DB id) into the paywall `identifier` (slug), then fetches that one paywall by identifier. The fetch-all is O(#paywalls) and **breaks for customers with many paywalls** (slow / times out).

Flow before this PR (`DebugViewController`):
1. `loadPreview()` → `network.getPaywalls()` (fetch-all)
2. `finishLoadingPreview()` → `paywalls.first { $0.databaseId == paywallDatabaseId }?.identifier`
3. `paywallRequestManager.getPaywall(from:)` (full paywall by identifier)

## Change

Replace the fetch-all + in-memory filter (steps 1–2) with a single resolver lookup, then keep the existing full-paywall fetch (step 3) untouched.

`GET /v2/paywalls/resolve?id=<id>` → `{ id, identifier, name }`, scoped to the application in the caller's token.

- **`API.swift`** — add a `.paywallsV2` endpoint host (base host + `/v2/` prefix; reachable via the `superwall.com/v2/*` → V2 Worker route).
- **`Endpoint.swift`** — add `resolvePaywall(byDatabaseId:retryCount:)`; remove the now-unused `paywalls()` endpoint.
- **`Network.swift`** — add `resolvePaywallIdentifier(forDatabaseId:)`; remove `getPaywalls()`.
- **`DebugViewController.swift`** — `finishLoadingPreview()` resolves the identifier with one request instead of filtering a fetched list; `loadPreview()` simplified.
- **`Paywall.swift`** — remove the now-unused `Paywalls` list model; add the small `PaywallIdentifierResolution` response model (kept in this existing file to avoid regenerating `project.pbxproj`).

## Authentication — updated since this PR was opened

The resolver is authenticated with the debugger's **signed preview token** (`sat_`) — the `token` already carried by the debug deep link (`superwall_debug=true&paywall_id=…&token=…`) — sent as `Authorization: Bearer <debugKey>` via `isForDebugging: true`.

**Not** the app's public key, as this description originally said. The debugger's QR preview flow never carries the public key, so the endpoint rejected it; the backend now verifies the `sat_` token instead (superwall/paywall-next#3583).

## The paywall picker — no longer removed

Earlier revisions of this PR removed the in-`DebugViewController` **"Your Paywalls" picker**, because it was populated from the fetch-all. It is now **restored**, so this PR costs no user-visible capability.

superwall/paywall-next#3657 adds `GET /v2/paywalls/preview-list`, returning `id` / `identifier` / `name` for the non-archived paywalls of the application in the same `sat_` token — no presentable paywall JSON. Enough to render the picker at a fraction of the old payload, fetched on demand instead of on every debugger launch.

- **`Paywall.swift`** — `PaywallPreviewList` / `PaywallPreviewListItem` decodables
- **`Endpoint.swift`** — `listPreviewPaywalls(retryCount:)` on the `.paywallsV2` host
- **`Network.swift`** — `listPreviewPaywalls()`, same `isForDebugging: true` auth, with a lower retry count since it only feeds an optional picker
- **`DebugViewController.swift`** — restores `previewPickerButton` (name, down arrow, tap target) and `pressedPreview`, keyed off `previewPaywalls`

Two deliberate behaviours:

- The list is fetched from `viewDidLoad` **alongside** the preview load, not after it. The picker is most useful precisely when the requested paywall fails to render, so it must not sit behind the preview's success path. A failure logs at `.warn` and leaves the picker empty rather than surfacing an error.
- `pressedPreview` requires **more than one** entry before opening — an action sheet offering only the paywall already on screen is noise.

`PaywallPreviewList` decodes only `data`. The endpoint also returns `object`, `has_more` and `application_id`; none are declared, so a future change to those fields can't throw `keyNotFound` and empty the picker.

## Testing

- `NetworkTests.resolvePaywall_endpointBuildsRequest` — asserts the endpoint builds `GET …/v2/paywalls/resolve?id=123` with an Authorization header.
- Verified on device: the debugger resolves a deep-link `paywall_id` and renders the paywall against production.

## Rollout

Backend ships first. All four backend PRs are merged to `paywall-next` `main`:

| PR | What |
|---|---|
| #3456 | the resolver endpoint |
| #3583 | switches it to `sat_` token auth |
| #3653 | registers the handler in the **production** wiring |
| #3657 | the `preview-list` endpoint behind the picker |

**#3653 matters for rollout.** The resolver was registered only in the test-layer wiring, not `server.ts`, so `/v2/paywalls/resolve` returned `401` on every host from 2026-07-03 until it was fixed — with a green test suite throughout. Confirm both endpoints return `404` (not `401`) for an unauthenticated request before merging:

```bash
curl -s -o /dev/null -w "%{http_code}\n" "https://api.superwall.com/v2/paywalls/resolve?id=1"
curl -s -o /dev/null -w "%{http_code}\n" "https://api.superwall.com/v2/paywalls/preview-list"
```

`404` = registered and reachable. `401` = not deployed.

Preview is debug-only, so an SDK build pointed at an environment without the endpoints degrades to a failed preview (and an empty picker), not a broken app.
