### PR TITLE
Capture first launch deep link for product page attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall/Superwall-iOS/releases) on GitHub.
 
+## 4.16.3
+
+### Enhancements
+
+- Saves the first deep link received during the first app session as the `firstDeepLinkUrl` user attribute. If you assign deep links to your App Store custom product pages, you can use this attribute to break down results and filter audiences by the product page that drove the install. Requires `Superwall.handleDeepLink(_:)` to be set up.
+
 ## 4.16.2
 
 ### Enhancements

--- a/Sources/SuperwallKit/DeepLinkRouter.swift
+++ b/Sources/SuperwallKit/DeepLinkRouter.swift
@@ -10,19 +10,29 @@ import Foundation
 import Combine
 
 final class DeepLinkRouter {
+  /// The user attribute key holding the first deep link URL received
+  /// during the first app session after install.
+  static let firstDeepLinkUrlAttributeKey = "firstDeepLinkUrl"
+
   private unowned let webEntitlementRedeemer: WebEntitlementRedeemer
   private unowned let debugManager: DebugManager
   private unowned let configManager: ConfigManager
+  private unowned let storage: Storage
+  private unowned let identityManager: IdentityManager
   private static var pendingDeepLink: URL?
 
   init(
     webEntitlementRedeemer: WebEntitlementRedeemer,
     debugManager: DebugManager,
-    configManager: ConfigManager
+    configManager: ConfigManager,
+    storage: Storage,
+    identityManager: IdentityManager
   ) {
     self.webEntitlementRedeemer = webEntitlementRedeemer
     self.debugManager = debugManager
     self.configManager = configManager
+    self.storage = storage
+    self.identityManager = identityManager
 
     listenToConfig()
   }
@@ -54,6 +64,8 @@ final class DeepLinkRouter {
       deepLinkUrl = url
     }
 
+    captureFirstSessionDeepLink(deepLinkUrl)
+
     Task {
       await Superwall.shared.track(InternalSuperwallEvent.DeepLink(url: deepLinkUrl))
     }
@@ -74,6 +86,40 @@ final class DeepLinkRouter {
     }
 
     return false
+  }
+
+  /// Captures the first deep link received during the first app session
+  /// as a user attribute.
+  ///
+  /// App Store custom product pages can each specify a deep link, which is
+  /// delivered on the first app open after install. Storing it as a user
+  /// attribute means campaign results can be broken down by custom product
+  /// page.
+  private func captureFirstSessionDeepLink(_ url: URL) {
+    if storage.recordFirstSessionDeepLink(url) {
+      identityManager.mergeUserAttributes(
+        [Self.firstDeepLinkUrlAttributeKey: url.absoluteString]
+      )
+    }
+  }
+
+  /// Re-applies the stored first-session deep link to the current user's
+  /// attributes. Called from `reset(duringIdentify:)` after user files are
+  /// wiped — the deep link is install-scoped, so the new user identity
+  /// inherits it, mirroring Apple Search Ads and MMP install attribution.
+  ///
+  /// - Warning: This must not read `identityManager.userAttributes`:
+  ///   `identify()` triggers the reset from the identity serial queue and the
+  ///   attributes getter is `queue.sync` on that same queue, which would
+  ///   deadlock. The merge is async and idempotent, so it's applied
+  ///   unconditionally.
+  func reapplyFirstSessionDeepLinkAttribute() {
+    guard let urlString = storage.get(FirstSessionDeepLinkURL.self) else {
+      return
+    }
+    identityManager.mergeUserAttributes(
+      [Self.firstDeepLinkUrlAttributeKey: urlString]
+    )
   }
 
   private func listenToConfig() {

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -190,7 +190,9 @@ final class DependencyContainer {
     deepLinkRouter = DeepLinkRouter(
       webEntitlementRedeemer: webEntitlementRedeemer,
       debugManager: debugManager,
-      configManager: configManager
+      configManager: configManager,
+      storage: storage,
+      identityManager: identityManager
     )
     purchaseManager = PurchaseManager(
       storeKitVersion: options.storeKitVersion,

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-4.16.2
+4.16.3
 """

--- a/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
+++ b/Sources/SuperwallKit/Storage/Cache/CacheKeys.swift
@@ -113,6 +113,20 @@ enum DidTrackFirstSession: Storable {
   typealias Value = Bool
 }
 
+/// The first deep link URL received during the first app session after
+/// install. App Store custom product pages can each specify a deep link
+/// that's delivered on the first app open, so this is stored for product
+/// page attribution. Install-scoped: survives identity reset so it can be
+/// re-applied to a new user's attributes, and is only cleared by app
+/// uninstall.
+enum FirstSessionDeepLinkURL: Storable {
+  static var key: String {
+    "store.firstSessionDeepLinkUrl"
+  }
+  static var directory: SearchPathDirectory = .appSpecificDocuments
+  typealias Value = String
+}
+
 enum DidCleanUserAttributes: Storable {
   static var key: String {
     "store.didCleanUserAttributes"

--- a/Sources/SuperwallKit/Storage/Storage.swift
+++ b/Sources/SuperwallKit/Storage/Storage.swift
@@ -349,3 +349,29 @@ class Storage {
     return cache.delete(keyType)
   }
 }
+
+// MARK: - First Session Deep Link
+extension Storage {
+  /// Records the first deep link received during the first app session.
+  ///
+  /// App Store custom product pages can each specify a deep link that's
+  /// delivered on the first app open after install. Storing it allows
+  /// results to be broken down by product page. Only the first deep link
+  /// received during the first app session is recorded. The stored value
+  /// is install-scoped, surviving identity resets.
+  ///
+  /// - Returns: `true` if this call recorded the URL, `false` if the first
+  ///   app session has already ended or a deep link was already recorded.
+  func recordFirstSessionDeepLink(_ url: URL) -> Bool {
+    queue.sync {
+      if _didTrackFirstSession {
+        return false
+      }
+      if get(FirstSessionDeepLinkURL.self) != nil {
+        return false
+      }
+      save(url.absoluteString, forType: FirstSessionDeepLinkURL.self)
+      return true
+    }
+  }
+}

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -1050,6 +1050,11 @@ public final class Superwall: NSObject, ObservableObject {
   /// - **`deepLink_open` trigger**: Any deep link can trigger a paywall if you've configured
   ///   a `deepLink_open` trigger in your Superwall dashboard.
   ///
+  /// The first deep link received during the first app session after install is
+  /// also saved as the `firstDeepLinkUrl` user attribute. If you assign deep links
+  /// to your App Store custom product pages, you can use this attribute to break
+  /// down results and filter audiences by the product page that drove the install.
+  ///
   /// This method is designed to work in a handler chain pattern where multiple handlers
   /// process deep links. It returns `true` only for URLs that Superwall will handle,
   /// allowing other handlers to process non-Superwall URLs.
@@ -1110,6 +1115,11 @@ public final class Superwall: NSObject, ObservableObject {
     // — the backend match only succeeds within the 7-day install window, so a
     // logout after that would otherwise leave the new user without attributes.
     dependencyContainer.mmpAttributionManager.reapplyCachedAcquisitionAttributes()
+
+    // The first-session deep link is install-scoped too. Re-apply it so the
+    // new user keeps the `firstDeepLinkUrl` attribute used for product page
+    // attribution.
+    dependencyContainer.deepLinkRouter.reapplyFirstSessionDeepLinkAttribute()
 
     dependencyContainer.paywallManager.resetCache()
     presentationItems.reset()

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-  s.version      = "4.16.2"
+  s.version      = "4.16.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		CF2064883604B915C8768FC5 /* ASIdManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF989B3D90DC3D88FACC4D45 /* ASIdManagerProxy.swift */; };
 		CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */; };
 		CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7EDB6D68D0AEDD332E40BB /* Superwall.swift */; };
+		D09F053C8458BD4DC5D8C385 /* FirstSessionDeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF63F804DD58D34FDF2BAB8 /* FirstSessionDeepLinkTests.swift */; };
 		D0E19F665C7B230BF3FA122D /* TrackingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED994DEC92BB90ACC6AC2 /* TrackingResult.swift */; };
 		D1F8771E65157D1B0E05D0B9 /* ManifestDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2915A802FACB53B6094B011 /* ManifestDataFetcher.swift */; };
 		D25B3A24CEE42FC90BFA31D2 /* SuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E4096EBF0B8C9693322CD1 /* SuperwallEvent.swift */; };
@@ -647,6 +648,7 @@
 		1A60698DFEF03837D029E191 /* TestModeEntitlementRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeEntitlementRowView.swift; sourceTree = "<group>"; };
 		1AB5B56470F69FBE1C34EAA8 /* PaywallRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequest.swift; sourceTree = "<group>"; };
 		1AD42859B8BFEC078665FA1E /* StripeStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeStoreProductDiscount.swift; sourceTree = "<group>"; };
+		1AF63F804DD58D34FDF2BAB8 /* FirstSessionDeepLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSessionDeepLinkTests.swift; sourceTree = "<group>"; };
 		1B1A6ADFFB9FA982BF69C134 /* MockSKPaymentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSKPaymentTransaction.swift; sourceTree = "<group>"; };
 		1B78FB9232236AF44369EA92 /* AppSessionManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManagerMock.swift; sourceTree = "<group>"; };
 		1BDB77756A3775FF4ED31C48 /* Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Email.swift; sourceTree = "<group>"; };
@@ -1724,6 +1726,7 @@
 			isa = PBXGroup;
 			children = (
 				0A9F09187825FB944A3BD8A9 /* DeepLinkRouterTests.swift */,
+				1AF63F804DD58D34FDF2BAB8 /* FirstSessionDeepLinkTests.swift */,
 			);
 			path = DeepLink;
 			sourceTree = "<group>";
@@ -3271,6 +3274,7 @@
 				CE43399599386456DCCD1FDC /* FakeLocationAuthorizationStatusTests.swift in Sources */,
 				1F9AE04458B942D070FC4832 /* FakeTrackingAuthorizationStatusTests.swift in Sources */,
 				AC7D527612F631AAADC7D225 /* FileManagerMigratorTests.swift in Sources */,
+				D09F053C8458BD4DC5D8C385 /* FirstSessionDeepLinkTests.swift in Sources */,
 				D4B5A9708204AB6D58904733 /* GetPaywallVcOperatorTests.swift in Sources */,
 				64B962A8B59ACE514B0E48AE /* GetPresenterOperatorTests.swift in Sources */,
 				AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */,

--- a/Tests/SuperwallKitTests/DeepLink/FirstSessionDeepLinkTests.swift
+++ b/Tests/SuperwallKitTests/DeepLink/FirstSessionDeepLinkTests.swift
@@ -1,0 +1,200 @@
+//
+//  FirstSessionDeepLinkTests.swift
+//  SuperwallKit
+//
+//  Tests for capturing the first deep link of the first app session
+//  as a user attribute for product page attribution.
+//
+// swiftlint:disable all
+
+import Testing
+import Foundation
+@testable import SuperwallKit
+
+// MARK: - Storage gating
+
+@Suite
+struct FirstSessionDeepLinkStorageTests {
+  private func makeStorage(cache: Cache = CacheMock()) -> Storage {
+    Storage(
+      factory: StorageMock.DeviceInfoFactoryMock(),
+      cache: cache
+    )
+  }
+
+  @Test("Records the deep link during the first app session")
+  func record_firstSession_recordsAndReturnsTrue() throws {
+    let storage = makeStorage()
+    let url = try #require(URL(string: "myapp://home?promo=summer"))
+
+    let didRecord = storage.recordFirstSessionDeepLink(url)
+
+    #expect(didRecord == true)
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == url.absoluteString)
+  }
+
+  @Test("Keeps the first recorded deep link when a second one arrives")
+  func record_secondLink_keepsFirst() throws {
+    let storage = makeStorage()
+    let firstUrl = try #require(URL(string: "myapp://home?promo=first"))
+    let secondUrl = try #require(URL(string: "myapp://home?promo=second"))
+
+    #expect(storage.recordFirstSessionDeepLink(firstUrl) == true)
+    #expect(storage.recordFirstSessionDeepLink(secondUrl) == false)
+
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == firstUrl.absoluteString)
+  }
+
+  @Test("Doesn't record when the first app session ended on a previous launch")
+  func record_notFirstSession_returnsFalse() throws {
+    let cache = CacheMock()
+    cache.write(true, forType: DidTrackFirstSession.self)
+    let storage = makeStorage(cache: cache)
+    let url = try #require(URL(string: "myapp://home?promo=summer"))
+
+    let didRecord = storage.recordFirstSessionDeepLink(url)
+
+    #expect(didRecord == false)
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == nil)
+  }
+
+  @Test("Doesn't record after the first session has been tracked")
+  func record_afterFirstSessionTracked_returnsFalse() throws {
+    let storage = makeStorage()
+    storage.recordFirstSessionTracked()
+    let url = try #require(URL(string: "myapp://home?promo=summer"))
+
+    let didRecord = storage.recordFirstSessionDeepLink(url)
+
+    #expect(didRecord == false)
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == nil)
+  }
+}
+
+// MARK: - Router capture
+
+@Suite(.serialized)
+struct FirstSessionDeepLinkRouterTests {
+  let dependencyContainer: DependencyContainer
+  let storage: Storage
+  let router: DeepLinkRouter
+
+  init() {
+    dependencyContainer = DependencyContainer()
+    storage = Storage(
+      factory: StorageMock.DeviceInfoFactoryMock(),
+      cache: CacheMock()
+    )
+    router = DeepLinkRouter(
+      webEntitlementRedeemer: dependencyContainer.webEntitlementRedeemer,
+      debugManager: dependencyContainer.debugManager,
+      configManager: dependencyContainer.configManager,
+      storage: storage,
+      identityManager: dependencyContainer.identityManager
+    )
+
+    // Remove any attribute persisted to disk by previous test runs.
+    let removal: [String: Any?] = [DeepLinkRouter.firstDeepLinkUrlAttributeKey: nil]
+    dependencyContainer.identityManager.mergeUserAttributes(removal)
+  }
+
+  private var storedAttribute: String? {
+    dependencyContainer.identityManager
+      .userAttributes[DeepLinkRouter.firstDeepLinkUrlAttributeKey] as? String
+  }
+
+  @Test("Routing a deep link during the first session sets the firstDeepLinkUrl user attribute")
+  func route_firstSession_setsUserAttribute() async throws {
+    let url = try #require(URL(string: "myapp://home?promo=\(UUID().uuidString)"))
+
+    router.route(url: url)
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == url.absoluteString)
+    #expect(storedAttribute == url.absoluteString)
+  }
+
+  @Test("Only the first deep link of the first session is captured")
+  func route_secondLink_keepsFirstAttribute() async throws {
+    let firstUrl = try #require(URL(string: "myapp://home?promo=\(UUID().uuidString)"))
+    let secondUrl = try #require(URL(string: "myapp://home?promo=\(UUID().uuidString)"))
+
+    router.route(url: firstUrl)
+    router.route(url: secondUrl)
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == firstUrl.absoluteString)
+    #expect(storedAttribute == firstUrl.absoluteString)
+  }
+
+  @Test("Superwall app-link deep links are captured in their mapped form")
+  func route_superwallAppLink_capturesMappedUrl() async throws {
+    let promo = UUID().uuidString
+    let url = try #require(
+      URL(string: "https://myapp.superwall.app/app-link/home?promo=\(promo)")
+    )
+
+    router.route(url: url)
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    // The mapped form is captured, consistent with the deepLink_open event.
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == "myapp://home?promo=\(promo)")
+    #expect(storedAttribute == "myapp://home?promo=\(promo)")
+  }
+
+  @Test("Redemption code deep links aren't captured for attribution")
+  func route_redemptionLink_doesNotCapture() async throws {
+    let superwall = Superwall(dependencyContainer: dependencyContainer)
+    let options = dependencyContainer.makeSuperwallOptions()
+    options.paywalls.shouldShowWebPurchaseConfirmationAlert = false
+    let mockNetwork = NetworkMock(
+      options: options,
+      factory: dependencyContainer
+    )
+    let redeemer = WebEntitlementRedeemer(
+      network: mockNetwork,
+      storage: storage,
+      entitlementsInfo: dependencyContainer.entitlementsInfo,
+      delegate: dependencyContainer.delegateAdapter,
+      purchaseController: MockPurchaseController(),
+      receiptManager: dependencyContainer.receiptManager,
+      factory: dependencyContainer,
+      superwall: superwall
+    )
+    let router = DeepLinkRouter(
+      webEntitlementRedeemer: redeemer,
+      debugManager: dependencyContainer.debugManager,
+      configManager: dependencyContainer.configManager,
+      storage: storage,
+      identityManager: dependencyContainer.identityManager
+    )
+    let url = try #require(URL(string: "myapp://superwall/redeem?code=TESTCODE"))
+
+    router.route(url: url)
+
+    #expect(storage.get(FirstSessionDeepLinkURL.self) == nil)
+
+    // Let the fire-and-forget redemption task finish against the mock network
+    // before the redeemer deallocates.
+    try await Task.sleep(nanoseconds: 500_000_000)
+  }
+
+  @Test("Re-applies the stored deep link to user attributes after a reset")
+  func reapply_appliesStoredLink() async throws {
+    let urlString = "myapp://home?promo=\(UUID().uuidString)"
+    storage.save(urlString, forType: FirstSessionDeepLinkURL.self)
+
+    router.reapplyFirstSessionDeepLinkAttribute()
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    #expect(storedAttribute == urlString)
+  }
+
+  @Test("Reapply is a no-op when no deep link was stored")
+  func reapply_noStoredLink_doesNotSetAttribute() async throws {
+    router.reapplyFirstSessionDeepLinkAttribute()
+    try await Task.sleep(nanoseconds: 300_000_000)
+
+    #expect(storedAttribute == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Implements [SW-5241](https://linear.app/superwall/issue/SW-5241/sdk-detect-first-launch-deep-link-for-product-page-attribution): App Store custom product pages (iOS 18+) can each specify a deep link that's delivered on the first app open after install. If `Superwall.handleDeepLink(_:)` is set up, the SDK now captures the first deep link received during the first app session and saves it as the `firstDeepLinkUrl` user attribute, so results can be broken down and audiences filtered by the product page that drove the install.

## How it works

- `DeepLinkRouter.route(url:)` is the single choke point every deep link flows through (static `handleDeepLink` post-config, the pre-config `pendingDeepLink` replay, the deprecated instance method, and the checkout web view). Capture happens at the same point the `deepLink_open` event is tracked, so:
  - Redemption-code URLs are **excluded** (they short-circuit earlier, consistent with them not producing `deepLink_open`).
  - Superwall app-links are captured in their **mapped** form, consistent with the URL tracked on `deepLink_open`.
- First-session gating uses `!didTrackFirstSession` (install-scoped, correct for existing users upgrading the SDK — they never capture). Only the first deep link of the first session is recorded.
- The URL is stored install-scoped (`.appSpecificDocuments`) and re-applied to the new user after `reset()`/`identify()`, mirroring Apple Search Ads and MMP install attribution. The re-apply deliberately avoids a sync read of `identityManager.userAttributes` — `identify()` triggers reset from the identity serial queue, so a sync read would deadlock (an adversarial review caught this; the same latent pattern exists in the MMP reapply path on `develop` and is tracked separately).
- Attribute syncs to the backend via the existing `user_attributes` event pipeline, so it respects `EventTrackingBehavior` the same way other attribution attributes do.

## Known limitations (accepted)

- A deep link stored pre-config replays through `route()` when config is retrieved; if the app is backgrounded before that (flipping `didTrackFirstSession`), the link isn't captured.
- The pre-config `pendingDeepLink` slot is last-wins (pre-existing behavior, unchanged).

## Tests

10 new Swift Testing tests in `FirstSessionDeepLinkTests.swift`: storage gating (first-session records once, first-wins, no capture after first session), router capture → user attribute merge, mapped-URL capture for Superwall app-links, redemption-link exclusion, and reset re-apply. Full suite run on iPhone 17 Pro (iOS 26.5): 879 tests in 94 suites — all pass except one pre-existing `CustomProductTests` flake that also fails on unmodified `develop` (a different test in that suite fails run-to-run).

## Checklist

- [x] All unit tests pass. (One pre-existing `CustomProductTests` flake fails intermittently on `develop` too — unrelated to this change.)
- [ ] All UI tests pass.
- [ ] Demo project builds and runs on iOS.
- [ ] Demo project builds and runs on Mac Catalyst.
- [ ] Demo project builds and runs on visionOS.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs. (SDK doc comments updated; online docs need a note about `firstDeepLinkUrl` for custom product page attribution.)
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements first-launch deep link capture for App Store custom product page attribution (SW-5241). When `Superwall.handleDeepLink(_:)` is called, the first deep link URL received during the first app session is stored install-scoped (`.appSpecificDocuments`) and merged into the user's attributes as `firstDeepLinkUrl`; it is re-applied after `reset()`/`identify()`, mirroring the existing ASA and MMP attribution re-apply pattern.

- `DeepLinkRouter.route()` is the single capture point — redemption-code URLs short-circuit before capture and Superwall app-links are captured in their mapped form, consistent with the `deepLink_open` event.
- `Storage.recordFirstSessionDeepLink()` gates capture on `!_didTrackFirstSession` (set when the app backgrounds) and a first-wins disk guard, ensuring only one URL is ever stored per install.
- 10 new Swift Testing tests cover storage gating, router capture, mapped-URL capture, redemption-link exclusion, and reset re-apply; the `@Suite(.serialized)` annotation prevents parallel interference between the stateful router tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core capture, gating, and re-apply logic is correct and well-tested.

The atomicity design in recordFirstSessionDeepLink is sound — serial-queue ordering guarantees that _didTrackFirstSession is observed consistently even when recordFirstSessionTracked is dispatched async. The install-scoped storage key correctly survives cleanUserFiles, and the deadlock risk in reapplyFirstSessionDeepLinkAttribute is correctly avoided and documented. The two remaining concerns are that every deep link during the first session triggers a synchronous disk read on the calling thread (unlike the in-memory shadow-variable pattern used elsewhere), and that the router tests use fixed 500 ms sleeps rather than queue-ordered synchronization, leaving them potentially flaky under CI load.

The recordFirstSessionDeepLink method in Storage.swift and the router integration tests in FirstSessionDeepLinkTests.swift would benefit from a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/DeepLinkRouter.swift | Adds captureFirstSessionDeepLink and reapplyFirstSessionDeepLinkAttribute; logic and thread-safety reasoning are sound; deadlock risk for reapply is correctly documented and avoided |
| Sources/SuperwallKit/Storage/Storage.swift | Adds recordFirstSessionDeepLink(_:) using queue.sync with disk I/O; correct atomicity but blocks calling thread (typically main) on every deep link during the first session, not just the first |
| Tests/SuperwallKitTests/DeepLink/FirstSessionDeepLinkTests.swift | Good coverage of storage gating and router capture; router tests rely on 500 ms Task.sleep for async attribute-merge synchronization, which is fragile on loaded CI |
| Sources/SuperwallKit/Storage/Cache/CacheKeys.swift | Adds FirstSessionDeepLinkURL storable with correct .appSpecificDocuments directory, ensuring it survives user resets |
| Sources/SuperwallKit/Superwall.swift | Adds reapplyFirstSessionDeepLinkAttribute() call in reset(duringIdentify:) mirroring the ASA and MMP re-apply pattern; doc comment updated for handleDeepLink |
| Sources/SuperwallKit/Dependencies/DependencyContainer.swift | Passes storage and identityManager into DeepLinkRouter constructor; straightforward wiring |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant DeepLinkRouter
    participant Storage
    participant IdentityManager

    App->>DeepLinkRouter: route(url:)
    alt redemption-code URL
        DeepLinkRouter-->>App: true (early return, no capture)
    else normal / Superwall app-link URL
        DeepLinkRouter->>DeepLinkRouter: map URL if Superwall app-link
        DeepLinkRouter->>Storage: recordFirstSessionDeepLink(url) [queue.sync]
        alt first session AND no URL stored yet
            Storage->>Storage: cache.write(url, FirstSessionDeepLinkURL)
            Storage-->>DeepLinkRouter: true
            DeepLinkRouter->>IdentityManager: mergeUserAttributes(["firstDeepLinkUrl": url]) [queue.async]
        else already recorded or session ended
            Storage-->>DeepLinkRouter: false (no-op)
        end
        DeepLinkRouter->>DeepLinkRouter: track deepLink_open event
        DeepLinkRouter-->>App: bool
    end

    Note over App,IdentityManager: On reset / identify...

    App->>DeepLinkRouter: reapplyFirstSessionDeepLinkAttribute()
    DeepLinkRouter->>Storage: get(FirstSessionDeepLinkURL)
    Storage-->>DeepLinkRouter: urlString (if stored)
    DeepLinkRouter->>IdentityManager: mergeUserAttributes(["firstDeepLinkUrl": urlString])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant DeepLinkRouter
    participant Storage
    participant IdentityManager

    App->>DeepLinkRouter: route(url:)
    alt redemption-code URL
        DeepLinkRouter-->>App: true (early return, no capture)
    else normal / Superwall app-link URL
        DeepLinkRouter->>DeepLinkRouter: map URL if Superwall app-link
        DeepLinkRouter->>Storage: recordFirstSessionDeepLink(url) [queue.sync]
        alt first session AND no URL stored yet
            Storage->>Storage: cache.write(url, FirstSessionDeepLinkURL)
            Storage-->>DeepLinkRouter: true
            DeepLinkRouter->>IdentityManager: mergeUserAttributes(["firstDeepLinkUrl": url]) [queue.async]
        else already recorded or session ended
            Storage-->>DeepLinkRouter: false (no-op)
        end
        DeepLinkRouter->>DeepLinkRouter: track deepLink_open event
        DeepLinkRouter-->>App: bool
    end

    Note over App,IdentityManager: On reset / identify...

    App->>DeepLinkRouter: reapplyFirstSessionDeepLinkAttribute()
    DeepLinkRouter->>Storage: get(FirstSessionDeepLinkURL)
    Storage-->>DeepLinkRouter: urlString (if stored)
    DeepLinkRouter->>IdentityManager: mergeUserAttributes(["firstDeepLinkUrl": urlString])
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Sources/SuperwallKit/Storage/Storage.swift:365-377
**Repeated disk read on every first-session deep link**

`queue.sync` is used to atomically check-and-write, which is correct. However, once the URL is stored (`get()` returns non-nil), every subsequent deep link during the first session still enters the sync block and performs a `cache.read()` disk read before returning `false`. The existing pattern for similar flags (e.g., `_didTrackFirstSeen`, `_didTrackFirstSession`) keeps an in-memory shadow variable that eliminates the disk round-trip on hot paths. Adding a `private var _didRecordFirstSessionDeepLink = false` (initialized from `cache.read(FirstSessionDeepLinkURL.self) != nil` in `init`, and set to `true` after the first successful write) would make all subsequent calls a pure in-memory check with no disk I/O.

### Issue 2 of 2
Tests/SuperwallKitTests/DeepLink/FirstSessionDeepLinkTests.swift:113
**Fixed sleep used as async-completion barrier**

`Task.sleep(nanoseconds: 500_000_000)` is used throughout the router tests to wait for `mergeUserAttributes` to propagate on the identity queue. This is fragile on loaded CI machines — a slow machine can take longer than 500 ms to schedule the async merge, causing spurious failures. Since `userAttributes` is already a `queue.sync` getter on the identity queue, wrapping the assertion in a helper that polls `storedAttribute` with a short sleep loop (or using `withCheckedContinuation`) would make the synchronization deterministic. The same pattern is used in all five router tests.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Capture first-session deep link as first..."](https://github.com/superwall/superwall-ios/commit/bbd5dfc9e816554c0f0fba5e0e849eada1ec99a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45660051)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->