### PR TITLE
Don't retry terminal HTTP errors, and surface them properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
-- Fixed network requests retrying on HTTP errors that can never succeed, such as `401 Unauthorized` and `404 Not Found`. These are now surfaced immediately instead of after the full retry schedule, which could take over a minute. Timeouts, rate limits and server errors (`408`, `425`, `429`, `499` and all `5xx`) are still retried as before.
-- Fixed HTTP error responses other than `401` and `404` being reported as decoding failures. A request that fails with, say, `403` or `500` now surfaces a `NetworkError.http(statusCode:)` carrying the status code, and is no longer tracked as a `network_decoding_fail` event.
+- Fixes network requests that can never succeed, such as those with an invalid API key, taking up to a minute to fail instead of failing straight away. Timeouts and server errors still retry as before.
+- Fixes failed network requests being reported as a decoding error rather than the HTTP error that actually occurred.
 
 ## 4.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixed network requests retrying on HTTP errors that can never succeed, such as `401 Unauthorized` and `404 Not Found`. These are now surfaced immediately instead of after the full retry schedule, which could take over a minute. Timeouts, rate limits and server errors (`408`, `425`, `429`, `499` and all `5xx`) are still retried as before.
+- Fixed HTTP error responses other than `401` and `404` being reported as decoding failures. A request that fails with, say, `403` or `500` now surfaces a `NetworkError.http(statusCode:)` carrying the status code, and is no longer tracked as a `network_decoding_fail` event.
 
 ## 4.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Adds the user's system-wide text size (Dynamic Type) as three device attributes for use in paywalls and audience filters: `fontScale`, `fontSize`, and `preferredContentSizeCategory`.
 - Links subscriptions to the user server-side after successful purchase or restore.
 
+### Fixes
+
+- Fixed network requests retrying on HTTP errors that can never succeed, such as `401 Unauthorized` and `404 Not Found`. These are now surfaced immediately instead of after the full retry schedule, which could take over a minute. Timeouts, rate limits and server errors (`408`, `425`, `429`, `499` and all `5xx`) are still retried as before.
+
 ## 4.16.1
 
 ### Enhancements

--- a/Sources/SuperwallKit/Misc/Extensions/Task+Retrying.swift
+++ b/Sources/SuperwallKit/Misc/Extensions/Task+Retrying.swift
@@ -30,6 +30,12 @@ extension Task where Failure == Error {
               if let (_, response) = result as? (Data, URLResponse),
                 let httpResponse = response as? HTTPURLResponse,
                 !(200...299).contains(httpResponse.statusCode) {
+                // A client error won't succeed on retry, so hand the response back
+                // for the caller to map rather than burning the whole backoff
+                // schedule on a request that can only fail the same way.
+                if TaskRetryLogic.isTerminal(statusCode: httpResponse.statusCode) {
+                  return result
+                }
                 throw URLError(.badServerResponse)
               }
               return result

--- a/Sources/SuperwallKit/Network/Custom URL Session/CustomURLSession.swift
+++ b/Sources/SuperwallKit/Network/Custom URL Session/CustomURLSession.swift
@@ -8,13 +8,17 @@
 
 import UIKit
 
-enum NetworkError: LocalizedError {
+enum NetworkError: LocalizedError, Equatable {
   case unknown
   case notAuthenticated
   case decoding
   case notFound
   case invalidUrl
   case noInternet
+
+  /// The server responded with a status code outside the 2xx range that isn't
+  /// covered by a more specific case.
+  case http(statusCode: Int)
 
   var errorDescription: String? {
     switch self {
@@ -24,6 +28,31 @@ enum NetworkError: LocalizedError {
     case .notFound: return NSLocalizedString("Not found", comment: "")
     case .invalidUrl: return NSLocalizedString("URL invalid", comment: "")
     case .noInternet: return NSLocalizedString("No Internet", comment: "")
+    case .http(let statusCode):
+      return String(
+        format: NSLocalizedString("HTTP error %d.", comment: ""),
+        statusCode
+      )
+    }
+  }
+
+  /// The error a response with the given status code should surface as, or `nil` if
+  /// the response was successful.
+  static func make(fromStatusCode statusCode: Int) -> NetworkError? {
+    switch statusCode {
+    case 200...299: return nil
+    case 401: return .notAuthenticated
+    case 404: return .notFound
+    default: return .http(statusCode: statusCode)
+    }
+  }
+
+  /// The message logged when a request fails with this error.
+  var logMessage: String {
+    switch self {
+    case .notAuthenticated: return "Unable to Authenticate"
+    case .notFound: return "Not Found"
+    default: return "Request Failed"
     }
   }
 }
@@ -132,36 +161,24 @@ class CustomURLSession {
         requestId = id
       }
 
-      if response.statusCode == 401 {
+      // Any non-2xx response is surfaced as an error. Without this, error responses
+      // fall through to decoding and are reported as `.decoding`, which describes
+      // the wrong failure and logs them as decoding failures.
+      if let error = NetworkError.make(fromStatusCode: response.statusCode) {
         Logger.debug(
           logLevel: .error,
           scope: .network,
-          message: "Unable to Authenticate",
+          message: error.logMessage,
           info: [
             "request": request.debugDescription,
             "api_key": auth ?? "N/A",
             "url": request.url?.absoluteString ?? "unknown",
+            "status_code": response.statusCode,
             "request_id": requestId,
             "request_duration": requestDuration
           ]
         )
-        throw NetworkError.notAuthenticated
-      }
-
-      if response.statusCode == 404 {
-        Logger.debug(
-          logLevel: .error,
-          scope: .network,
-          message: "Not Found",
-          info: [
-            "request": request.debugDescription,
-            "api_key": auth ?? "N/A",
-            "url": request.url?.absoluteString ?? "unknown",
-            "request_id": requestId,
-            "request_duration": requestDuration
-          ]
-        )
-        throw NetworkError.notFound
+        throw error
       }
     }
 

--- a/Sources/SuperwallKit/Network/Custom URL Session/TaskRetryLogic.swift
+++ b/Sources/SuperwallKit/Network/Custom URL Session/TaskRetryLogic.swift
@@ -34,10 +34,15 @@ enum TaskRetryLogic {
 
   /// Whether a response with this status code will never succeed on retry.
   ///
-  /// Only client errors are terminal. Server errors (5xx) and the retryable client
-  /// errors above are worth sending again.
+  /// Server errors (5xx) and the retryable client errors above are worth sending
+  /// again. Everything else outside the 2xx range returns the same result however
+  /// many times it's sent, including a redirect that reached us because it couldn't
+  /// be followed.
   static func isTerminal(statusCode: Int) -> Bool {
-    guard (400...499).contains(statusCode) else {
+    if (200...299).contains(statusCode) {
+      return false
+    }
+    if (500...599).contains(statusCode) {
       return false
     }
     return !retryableClientErrorCodes.contains(statusCode)

--- a/Sources/SuperwallKit/Network/Custom URL Session/TaskRetryLogic.swift
+++ b/Sources/SuperwallKit/Network/Custom URL Session/TaskRetryLogic.swift
@@ -23,4 +23,23 @@ enum TaskRetryLogic {
     let oneSecond = TimeInterval(1_000_000_000)
     return UInt64(oneSecond * delay)
   }
+
+  /// Client error codes that may still succeed if the request is sent again.
+  private static let retryableClientErrorCodes: Set<Int> = [
+    408, // Request Timeout
+    425, // Too Early
+    429, // Too Many Requests
+    499  // Client Closed Request
+  ]
+
+  /// Whether a response with this status code will never succeed on retry.
+  ///
+  /// Only client errors are terminal. Server errors (5xx) and the retryable client
+  /// errors above are worth sending again.
+  static func isTerminal(statusCode: Int) -> Bool {
+    guard (400...499).contains(statusCode) else {
+      return false
+    }
+    return !retryableClientErrorCodes.contains(statusCode)
+  }
 }

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -547,6 +547,7 @@
 		F5F8C2E02A057DA15C2936AB /* StorePresentationObjectsOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D233EACAB5090B0657D /* StorePresentationObjectsOperatorTests.swift */; };
 		F5FBA532DB79848B0537720F /* PresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94125DB9AC8A2EA66F983EDA /* PresentationResult.swift */; };
 		F605AA51AB24B564D3A21B07 /* Paywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E6981E6A6574EE72B65A9E /* Paywall.swift */; };
+		F60F60B64FAB0670C87F43CA /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF59C083B597BBF7C8F8503F /* NetworkErrorTests.swift */; };
 		F61541FC6670E0667A96FE44 /* ArchiveManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D8461640AE665CF5A54016 /* ArchiveManifest.swift */; };
 		F75F5E1D503B9391ADD812EC /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C2B369C690AAB9C085E2E9 /* PKCS7.swift */; };
 		F79C378E19116B9312AE5873 /* ASN1Decoder+Unboxing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70FC86C1189200C486627EAD /* ASN1Decoder+Unboxing.swift */; };
@@ -1041,6 +1042,7 @@
 		BD9CFF209DA6B8B42B405D20 /* LocationAuthorizationStatusConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAuthorizationStatusConversionTests.swift; sourceTree = "<group>"; };
 		BF091A5565631C9F426F304B /* LocalizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationManager.swift; sourceTree = "<group>"; };
 		BF3CE3353B30F2484EFE283E /* PlacementsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacementsQueue.swift; sourceTree = "<group>"; };
+		BF59C083B597BBF7C8F8503F /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		BF61DCA9CF170E0AFC507BAE /* PaywallMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessageHandler.swift; sourceTree = "<group>"; };
 		BFE42FD8C7F01915D74D0008 /* Trackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trackable.swift; sourceTree = "<group>"; };
 		C054891709C534F59C93C815 /* URLSessionRetryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRetryLogicTests.swift; sourceTree = "<group>"; };
@@ -1338,6 +1340,7 @@
 			children = (
 				35F538F901BAF97DDCA86F84 /* DeviceHelperMock.swift */,
 				FB28BCE1EE94BFE935B984AB /* DeviceHelperTests.swift */,
+				BF59C083B597BBF7C8F8503F /* NetworkErrorTests.swift */,
 				10D5ABDB23D56393EFDCF73A /* NetworkMock.swift */,
 				F2A2A54314BAEAF65B46D322 /* NetworkTests.swift */,
 				B5768D312352E16D6AC021D2 /* Custom URL Session */,
@@ -3295,6 +3298,7 @@
 				F15479C499547FE1B47DEA6B /* MockSkProduct.swift in Sources */,
 				A51060CF6339BF9383F94B51 /* MockSubscriptionPeriod.swift in Sources */,
 				CD9D1217629293A3B8379F9F /* MockSuperwallDelegate.swift in Sources */,
+				F60F60B64FAB0670C87F43CA /* NetworkErrorTests.swift in Sources */,
 				4EFA142D3D37B0564BDB52CB /* NetworkMock.swift in Sources */,
 				58185F7A0770111BDE259936 /* NetworkTests.swift in Sources */,
 				F0013E500B7F2113857F8161 /* NotificationSchedulerTests.swift in Sources */,

--- a/Tests/SuperwallKitTests/Misc/Extensions/TaskRetryingTests.swift
+++ b/Tests/SuperwallKitTests/Misc/Extensions/TaskRetryingTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import Foundation
 @testable import SuperwallKit
 
 struct TaskRetryingTests {
@@ -53,5 +54,75 @@ struct TaskRetryingTests {
 
     // Expect 3 retries (3 failures)
     #expect(attemptCounter == 3)
+  }
+
+  // MARK: - HTTP status handling
+
+  /// Counts how many times the retried operation actually ran.
+  private actor CallCounter {
+    private(set) var count = 0
+
+    func increment() {
+      count += 1
+    }
+  }
+
+  private static func makeResponse(_ statusCode: Int) -> (Data, URLResponse) {
+    let url = URL(string: "https://api.superwall.com/test")!
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+    return (Data(), response)
+  }
+
+  /// Runs `Task.retrying` against a stubbed HTTP status and reports how many times
+  /// the operation was invoked.
+  private func callCount(forStatusCode statusCode: Int) async -> Int {
+    let counter = CallCounter()
+
+    let task = Task.retrying(
+      maxRetryCount: 3,
+      retryInterval: 0.01,
+      isRetryingCallback: nil
+    ) {
+      await counter.increment()
+      return Self.makeResponse(statusCode)
+    }
+
+    _ = try? await task.value
+    return await counter.count
+  }
+
+  @Test(
+    "Does not retry terminal client errors",
+    arguments: [400, 401, 403, 404, 410, 422]
+  )
+  func terminalClientErrorsAreNotRetried(statusCode: Int) async {
+    #expect(await callCount(forStatusCode: statusCode) == 1)
+  }
+
+  @Test(
+    "Retries client errors that may succeed on a retry",
+    arguments: [408, 425, 429, 499]
+  )
+  func retryableClientErrorsAreRetried(statusCode: Int) async {
+    // 3 attempts in the retry loop, plus the final unchecked attempt.
+    #expect(await callCount(forStatusCode: statusCode) == 4)
+  }
+
+  @Test(
+    "Retries server errors",
+    arguments: [500, 502, 503]
+  )
+  func serverErrorsAreRetried(statusCode: Int) async {
+    #expect(await callCount(forStatusCode: statusCode) == 4)
+  }
+
+  @Test("Does not retry a successful response")
+  func successIsNotRetried() async {
+    #expect(await callCount(forStatusCode: 200) == 1)
   }
 }

--- a/Tests/SuperwallKitTests/Misc/Extensions/TaskRetryingTests.swift
+++ b/Tests/SuperwallKitTests/Misc/Extensions/TaskRetryingTests.swift
@@ -105,6 +105,14 @@ struct TaskRetryingTests {
   }
 
   @Test(
+    "Does not retry redirects that reach the caller",
+    arguments: [301, 302, 307, 308]
+  )
+  func redirectsAreNotRetried(statusCode: Int) async {
+    #expect(await callCount(forStatusCode: statusCode) == 1)
+  }
+
+  @Test(
     "Retries client errors that may succeed on a retry",
     arguments: [408, 425, 429, 499]
   )

--- a/Tests/SuperwallKitTests/Network/Custom URL Session/URLSessionRetryLogicTests.swift
+++ b/Tests/SuperwallKitTests/Network/Custom URL Session/URLSessionRetryLogicTests.swift
@@ -27,4 +27,24 @@ struct URLSessionRetryLogicTests {
     )
     #expect(delay == nil)
   }
+
+  @Test(arguments: [400, 401, 403, 404, 405, 410, 422])
+  func isTerminal_clientErrors(statusCode: Int) {
+    #expect(TaskRetryLogic.isTerminal(statusCode: statusCode))
+  }
+
+  @Test(arguments: [408, 425, 429, 499])
+  func isTerminal_retryableClientErrors(statusCode: Int) {
+    #expect(!TaskRetryLogic.isTerminal(statusCode: statusCode))
+  }
+
+  @Test(arguments: [500, 502, 503, 504])
+  func isTerminal_serverErrors(statusCode: Int) {
+    #expect(!TaskRetryLogic.isTerminal(statusCode: statusCode))
+  }
+
+  @Test(arguments: [200, 201, 204, 301, 304])
+  func isTerminal_nonErrors(statusCode: Int) {
+    #expect(!TaskRetryLogic.isTerminal(statusCode: statusCode))
+  }
 }

--- a/Tests/SuperwallKitTests/Network/Custom URL Session/URLSessionRetryLogicTests.swift
+++ b/Tests/SuperwallKitTests/Network/Custom URL Session/URLSessionRetryLogicTests.swift
@@ -43,8 +43,15 @@ struct URLSessionRetryLogicTests {
     #expect(!TaskRetryLogic.isTerminal(statusCode: statusCode))
   }
 
-  @Test(arguments: [200, 201, 204, 301, 304])
-  func isTerminal_nonErrors(statusCode: Int) {
+  @Test(arguments: [200, 201, 204, 299])
+  func isTerminal_successfulResponses(statusCode: Int) {
     #expect(!TaskRetryLogic.isTerminal(statusCode: statusCode))
+  }
+
+  /// A redirect only reaches us when `URLSession` couldn't follow it, and it will
+  /// come back the same way every time, so there's nothing to gain from retrying.
+  @Test(arguments: [301, 302, 303, 307, 308])
+  func isTerminal_redirects(statusCode: Int) {
+    #expect(TaskRetryLogic.isTerminal(statusCode: statusCode))
   }
 }

--- a/Tests/SuperwallKitTests/Network/NetworkErrorTests.swift
+++ b/Tests/SuperwallKitTests/Network/NetworkErrorTests.swift
@@ -1,0 +1,60 @@
+//
+//  NetworkErrorTests.swift
+//  SuperwallKitTests
+//
+//  Created by Yusuf Tör on 27/07/2026.
+//
+
+import Testing
+@testable import SuperwallKit
+
+struct NetworkErrorTests {
+  @Test("Successful responses produce no error", arguments: [200, 201, 202, 204, 299])
+  func make_successfulResponses(statusCode: Int) {
+    #expect(NetworkError.make(fromStatusCode: statusCode) == nil)
+  }
+
+  @Test("401 keeps its dedicated error")
+  func make_unauthorized() {
+    #expect(NetworkError.make(fromStatusCode: 401) == .notAuthenticated)
+  }
+
+  @Test("404 keeps its dedicated error")
+  func make_notFound() {
+    #expect(NetworkError.make(fromStatusCode: 404) == .notFound)
+  }
+
+  @Test(
+    "Other client errors surface the status code rather than a decoding failure",
+    arguments: [400, 403, 405, 410, 422, 429]
+  )
+  func make_otherClientErrors(statusCode: Int) {
+    #expect(NetworkError.make(fromStatusCode: statusCode) == .http(statusCode: statusCode))
+  }
+
+  @Test(
+    "Server errors surface the status code rather than a decoding failure",
+    arguments: [500, 502, 503, 504]
+  )
+  func make_serverErrors(statusCode: Int) {
+    #expect(NetworkError.make(fromStatusCode: statusCode) == .http(statusCode: statusCode))
+  }
+
+  @Test("Redirects that reach the caller are treated as errors")
+  func make_redirect() {
+    #expect(NetworkError.make(fromStatusCode: 302) == .http(statusCode: 302))
+  }
+
+  @Test("The status code is included in the error description")
+  func errorDescription_includesStatusCode() {
+    let error = NetworkError.http(statusCode: 403)
+    #expect(error.errorDescription?.contains("403") == true)
+  }
+
+  @Test("Log messages are preserved for the dedicated cases")
+  func logMessage() {
+    #expect(NetworkError.notAuthenticated.logMessage == "Unable to Authenticate")
+    #expect(NetworkError.notFound.logMessage == "Not Found")
+    #expect(NetworkError.http(statusCode: 403).logMessage == "Request Failed")
+  }
+}


### PR DESCRIPTION
## Changes in this pull request

Fixes #492, plus a related error-reporting problem found while working on it.

**1. Terminal HTTP errors are no longer retried** (`cd31438d3`)

`Task.retrying` threw `URLError(.badServerResponse)` for any non-2xx response, which its own `catch` immediately swallowed and retried. A permanent failure such as `401` or `404` therefore burned the full backoff schedule before surfacing:

| attempt | sleep | | attempt | sleep |
|---|---|---|---|---|
| 0 | 5.0s | | 3 | 11.2s |
| 1 | 6.5s | | 4 | 14.6s |
| 2 | 8.5s | | 5 | 19.1s |

That's **~65s and 7 round-trips** at the default `retryCount` of 6, for a request that could only ever fail the same way.

Terminal statuses now return the response immediately instead of throwing. This matches what already happened once retries were exhausted — the loop's final attempt returns the response unchecked — so callers see the same error, just without the wasted requests and delay.

Per @anglinb's review note on the issue, client errors that may succeed on a retry are explicitly excluded and keep their existing behaviour: `408` Request Timeout, `425` Too Early, `429` Too Many Requests, `499` Client Closed Request. All `5xx` are unaffected.

**2. HTTP errors are no longer reported as decoding failures** (`d9fbbf7f2`)

`getRequestId` only threw for `401` and `404`. Every other non-2xx response returned normally, so the error body was then decoded as if it were a success payload. That failed, and the caller received `NetworkError.decoding` — describing the wrong failure — while the SDK tracked a `network_decoding_fail` event for what was really an HTTP error.

Adds `NetworkError.http(statusCode:)` and classifies every non-2xx response through a new `NetworkError.make(fromStatusCode:)`. `401` and `404` keep their dedicated cases and log messages, so nothing matching on those changes behaviour. The three near-identical logging blocks collapse into one that also records the status code.

Note: `NetworkError` needed an explicit `Equatable` conformance, because adding an associated value drops the conformance simple enums get implicitly — and `PaywallLogic.handlePaywallError` relies on it for `error == .notFound`.

**3. Redirects classify consistently across both paths** (`671d6a2b7`)

The two changes above initially disagreed about 3xx. `NetworkError.make(fromStatusCode:)` treats any non-2xx response as an error, but `TaskRetryLogic.isTerminal` only considered 4xx terminal — so a redirect would have burned the full retry schedule before surfacing as `.http(statusCode:)`. The tests asserted both opinions, so the suite documented the contradiction rather than catching it.

A redirect only reaches the caller when `URLSession` couldn't follow it — a 3xx with no `Location` header, for instance — and it comes back the same way however many times it's sent. `isTerminal` is now framed as "not 2xx, and retrying can't help", so both paths agree for every status code.

The commits are kept separate: the first is a pure latency fix with no API change, the second alters the SDK's internal error surface, the third reconciles them. `NetworkError` is not public, so integrators are unaffected either way.

### Verification

888 tests in 93 suites pass. New coverage asserts actual invocation counts through the real `Task.retrying` (1 call for a `401`, 4 for a `429`), not just the predicate:

- `401`/`404` keep their existing errors — regression guard for the compatibility claim above
- terminal client errors are not retried: `400`, `401`, `403`, `404`, `410`, `422`
- redirects are not retried and surface as errors: `301`, `302`, `303`, `307`, `308`
- retryable client errors still retry: `408`, `425`, `429`, `499`
- server errors still retry: `500`, `502`, `503`
- status-code classification, error description and log messages

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass. — not run
- [ ] Demo project builds and runs on iOS. — not run
- [ ] Demo project builds and runs on Mac Catalyst. — not run
- [ ] Demo project builds and runs on visionOS. — not run
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs. — no public API changed, so no docs update needed
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves HTTP failure handling.
- Stops retrying terminal 4xx responses while preserving retries for 408, 425, 429, 499, and 5xx responses.
- Adds status-aware HTTP errors so non-2xx responses no longer surface as decoding failures.
- Adds retry-count, status classification, error-description, and logging-message tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with terminal and retryable HTTP statuses handled consistently through the request pipeline.

The changed retry classification matches the added invocation-count tests, and existing callers either generically propagate or handle the new status-aware errors without relying on the former decoding behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/SuperwallKit/Misc/Extensions/Task+Retrying.swift | Returns terminal 4xx responses immediately while retaining the existing retry path for transient statuses. |
| Sources/SuperwallKit/Network/Custom URL Session/TaskRetryLogic.swift | Centralizes terminal-client-error classification with explicit exceptions for retryable 4xx statuses. |
| Sources/SuperwallKit/Network/Custom URL Session/CustomURLSession.swift | Introduces status-bearing HTTP errors and consistently classifies every non-2xx response before decoding. |
| Tests/SuperwallKitTests/Misc/Extensions/TaskRetryingTests.swift | Verifies actual invocation counts for successful, terminal, retryable-client, and server responses. |
| Tests/SuperwallKitTests/Network/NetworkErrorTests.swift | Covers HTTP status mapping, localized descriptions, and preserved dedicated-case log messages. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Retry as Task.retrying
  participant Backend
  participant Session as CustomURLSession
  Caller->>Retry: Start request
  Retry->>Backend: Send HTTP request
  Backend-->>Retry: HTTP response
  alt Terminal 4xx
    Retry-->>Session: Return response immediately
  else Retryable 4xx or 5xx
    Retry->>Backend: Retry with backoff
    Backend-->>Retry: Final response
    Retry-->>Session: Return response
  else Successful 2xx
    Retry-->>Session: Return response
  end
  alt Non-2xx
    Session-->>Caller: Throw classified NetworkError
  else 2xx
    Session-->>Caller: Decode response
  end
```

<sub>Reviews (1): Last reviewed commit: ["Surface HTTP errors instead of reporting..."](https://github.com/superwall/superwall-ios/commit/d9fbbf7f2a7371309bf21071afcc21171566ce27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47568740)</sub>

**Context used:**

- Knowledge Base — [Networking Layer](https://app.greptile.com/superwall/-/custom-context/knowledge-base/superwall/superwall-ios/-/docs/networking-layer.md)

<!-- /greptile_comment -->
